### PR TITLE
Skip normalisation when the data format version is 0.2.0

### DIFF
--- a/pipeline/batch/daily_workflow.py
+++ b/pipeline/batch/daily_workflow.py
@@ -518,12 +518,15 @@ class NormaliseReport(luigi.Task):
 
         entry['bucket_date'] = bucket_date
 
-        entry['test_start_time'] = datetime.fromtimestamp(entry.pop('start_time',
-                                        0)).strftime("%Y-%m-%d %H:%M:%S")
-
         entry['id'] = entry.get('id', str(uuid.uuid4()))
         entry['report_filename'] = os.path.join(bucket_date,
                                     os.path.basename(self.output().path))
+
+        if entry.get('data_format_version', '0.1.0') == '0.2.0':
+            return entry
+
+        entry['test_start_time'] = datetime.fromtimestamp(entry.pop('start_time',
+                                        0)).strftime("%Y-%m-%d %H:%M:%S")
         entry['data_format_version'] = '0.2.0'
 
         if isinstance(entry.get('options', []), dict):


### PR DESCRIPTION
With this PR we skip running all the normalisation when the data format is already at the latest version.
