### PR TITLE
Create a multicolumn index on test_start_time and probe_cc

### DIFF
--- a/pipeline/batch/sql_tasks.py
+++ b/pipeline/batch/sql_tasks.py
@@ -331,6 +331,7 @@ class CreateIndexes(RunQuery):
             sql += 'CREATE INDEX {index_key}_idx ON metrics ({index_key});\n'.format(
                  index_key=index_key
             )
+        sql += 'CREATE INDEX test_start_time_probe_cc_idx ON metrics (test_start_time DESC, probe_cc);'
         return sql
 
 if __name__ == "__main__":


### PR DESCRIPTION
This leads to a significant performance boost to queries on countries
with few measurements (query time for common queries went from 396000ms to 300ms)
