### PR TITLE
Refresh materialized views concurrently

### DIFF
--- a/pipeline/batch/daily_workflow.py
+++ b/pipeline/batch/daily_workflow.py
@@ -844,7 +844,7 @@ class UpdateView(RunQuery):
 
     view = ''
     def query(self):
-        return 'REFRESH MATERIALIZED VIEW {view};\n'.format(view=self.view)
+        return 'REFRESH MATERIALIZED VIEW CONCURRENTLY {view};\n'.format(view=self.view)
 
 class UpdateCountryCount(UpdateView):
     view = 'country_counts_view'


### PR DESCRIPTION
Prior to this materialized view updates lead to the database tables
related to these views will be locked (also for read), which makes the
explorer UI irresponsive during the 1 hour or so that the materialized
views are being updated.
This makes it happen concurrently, which means that the updated view is
written to a temporary table and then renamed in place, making the old
table still accessible while the update is in progress.
