### PR TITLE
centrifugation: calculate simhash(body) and simhash(text(body))

### DIFF
--- a/af/mubench/hash64_shingles.py
+++ b/af/mubench/hash64_shingles.py
@@ -2,10 +2,13 @@
 
 import re
 import itertools
+import struct
 from hashlib import sha1
+from hashlib import md5
 
-import mmh3     # mmh3=2.3.1
-import xxhash   # xxhash=1.0.0
+import mmh3     # mmh3=2.5.1
+import xxhash   # xxhash=1.3.0
+import simhash  # simhash-py==0.4.0
 
 # string.whitespace + string.punctuation, it's not so smart, e.g. "I.B.M." is
 # signe token in ideal world.
@@ -13,6 +16,80 @@ RE_DELIM = re.compile('''[\t\n\x0b\x0c\r !"#$%&\'()*+,-./:;<=>?@[\\\\\\]^_`{|}~'
 
 TEXT = open('warning.rt.ru.html').read()
 assert len(TEXT) == 10824 and sha1(TEXT).hexdigest() == '1575ad5cc6e6db27057cd73dae6a94addfd965b2'
+
+def prepare():
+    i1, i2 = itertools.tee(RE_DELIM.finditer(TEXT))
+    for i in xrange(4):
+        next(i2, None)
+    return itertools.izip(i1, i2) # iterator over beginning and the end of the shingle
+
+def baseline(): # 1000 loops, best of 50: 268 usec per loop
+    for m1, m2 in prepare():
+        pass
+
+def baseline_str(): # 100 loops, best of 100: 430 usec per loop
+    for m1, m2 in prepare():
+        i = TEXT[m1.end():m2.start()]
+
+def baseline_hash_u64(): # 100 loops, best of 100: 568 usec per loop
+    for m1, m2 in prepare():
+        i = hash(TEXT[m1.end():m2.start()]) & 0xFFFFFFFFFFFFFFFF
+
+def simhash_u64(): # 100 loops, best of 100: 1.39 msec per loop
+    unsigned_hash = simhash.unsigned_hash
+    for m1, m2 in prepare():
+        i = unsigned_hash(TEXT[m1.end():m2.start()])
+
+def simhash_md5_u64(): # 100 loops, best of 100: 1.47 msec per loop
+    for m1, m2 in prepare():
+        digest = md5(TEXT[m1.end():m2.start()]).digest()[0:8]
+        i = struct.unpack('>Q', digest)[0] & 0xFFFFFFFFFFFFFFFF
+
+def sha1_u64(): # 100 loops, best of 100: 1.41 msec per loop
+    for m1, m2 in prepare():
+        digest = sha1(TEXT[m1.end():m2.start()]).digest()[0:8]
+        i = struct.unpack('>Q', digest)[0] & 0xFFFFFFFFFFFFFFFF
+
+def sha1_u64_v1(): # 100 loops, best of 100: 1.29 msec per loop
+    unpacker = struct.Struct('>Q')
+    for m1, m2 in prepare():
+        digest = sha1(TEXT[m1.end():m2.start()]).digest()[0:8]
+        i = unpacker.unpack(digest)[0]
+
+def sha1_u64_v2(): # 100 loops, best of 100: 1.35 msec per loop
+    unpacker = struct.Struct('>Q')
+    for m1, m2 in prepare():
+        digest = sha1(TEXT[m1.end():m2.start()]).digest()
+        i = unpacker.unpack_from(digest)[0]
+
+def mmh3_u64_v1(): # 100 loops, best of 100: 880 usec per loop
+    for m1, m2 in prepare():
+        i = mmh3.hash64(TEXT[m1.end():m2.start()], signed=False)[0]
+
+def mmh3_u64_v2(): # 100 loops, best of 100: 715 usec per loop
+    for m1, m2 in prepare():
+        i = mmh3.hash64(TEXT[m1.end():m2.start()], 0, True, False)[0]
+
+def mmh3_u64_v3(): # 100 loops, best of 100: 690 usec per loop
+    for m1, m2 in prepare():
+        i = mmh3.hash64(TEXT[m1.end():m2.start()])[0] & 0xFFFFFFFFFFFFFFFF
+
+def mmh3_u64_v4(): # 100 loops, best of 100: 661 usec per loop
+    hash64 = mmh3.hash64
+    for m1, m2 in prepare():
+        i = hash64(TEXT[m1.end():m2.start()])[0] & 0xFFFFFFFFFFFFFFFF
+
+def xxhash_u64_v1(): # 100 loops, best of 100: 700 usec per loop
+    for m1, m2 in prepare():
+        i = xxhash.xxh64_intdigest(TEXT[m1.end():m2.start()])
+
+def xxhash_u64_v2(): # 100 loops, best of 100: 676 usec per loop
+    xxh64_intdigest = xxhash.xxh64_intdigest
+    for m1, m2 in prepare():
+        i = xxh64_intdigest(TEXT[m1.end():m2.start()])
+
+########################################################################
+# Following are historical numbers for mmh3=2.3.1 xxhash=1.0.0
 
 # python2.7 -m timeit -v --repeat 20 --number 500 'import bench as b' 'b.main()'
 def main():

--- a/af/mubench/warning.rt.ru.html
+++ b/af/mubench/warning.rt.ru.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <!-- «Доступ запрещён» -->
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="./static/warning/css/fonts.css">
+    <link rel="stylesheet" href="./static/warning/css/main.css">
+    <link rel="shortcut icon" href="./static/warning/favicon.ico">
+<!--[if lte IE 9]>
+<script src="http://html5shiv-printshiv.googlecode.com/svn/trunk/html5shiv-printshiv.js"></script>
+<![endif]-->
+<title>Доступ ограничен</title>
+<!-- Yandex.Metrika counter -->
+<script type="text/javascript">
+    (function (d, w, c) {
+        (w[c] = w[c] || []).push(function() {
+            try {
+                w.yaCounter31081271 = new Ya.Metrika({
+                    id:31081271,
+                    clickmap:true,
+                    trackLinks:true,
+                    accurateTrackBounce:true,
+                    trackHash:true,
+                    ut:"noindex"
+                });
+            } catch(e) { }
+        });
+
+        var n = d.getElementsByTagName("script")[0],
+        s = d.createElement("script"),
+        f = function () { n.parentNode.insertBefore(s, n); };
+        s.type = "text/javascript";
+        s.async = true;
+        s.src = "https://mc.yandex.ru/metrika/watch.js";
+
+        if (w.opera == "[object Opera]") {
+            d.addEventListener("DOMContentLoaded", f, false);
+        } else { f(); }
+    })(document, window, "yandex_metrika_callbacks");
+</script>
+<noscript><div><img src="https://mc.yandex.ru/watch/31081271?ut=noindex" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<!-- /Yandex.Metrika counter -->
+<!-- Yandex.Metrika counter RTK-->
+<script type="text/javascript">
+    (function (d, w, c) {
+        var rtkCounterId = 38740850,
+            push = Array.prototype.push,
+            goals_queue = [];
+
+        w.RTKGoal = function(goals2push) {            
+            goals2push &&
+                push.apply(goals_queue, goals2push);
+                
+            if(w['yaCounter' + rtkCounterId]) {
+                while(goals_queue.length) {
+                    w['yaCounter' + rtkCounterId].reachGoal(goals_queue.shift());
+                }
+            }
+        };
+        (w[c] = w[c] || []).push(function() {
+            try {
+                w.counterId = 38740850;
+                w.yaCounter38740850 = new Ya.Metrika({
+                    id:38740850,
+                    clickmap:true,
+                    trackLinks:true,
+                    accurateTrackBounce:true,
+                    webvisor:true
+                });
+                RTKGoal();
+            } catch(e) { }
+        });
+
+        var n = d.getElementsByTagName("script")[0],
+            s = d.createElement("script"),
+            f = function () { n.parentNode.insertBefore(s, n); };
+        s.type = "text/javascript";
+        s.async = true;
+        s.src = "https://mc.yandex.ru/metrika/watch.js";
+
+        if (w.opera == "[object Opera]") {
+            d.addEventListener("DOMContentLoaded", f, false);
+        } else { f(); }
+    })(document, window, "yandex_metrika_callbacks");
+</script>
+<noscript><div><img src="https://mc.yandex.ru/watch/38740850" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+<!-- /Yandex.Metrika counter -->
+
+
+</head>
+<body>
+
+    <div class="header">
+        <div class="container">
+            <a href="http://rt.ru" target="_blank">
+                <img src="./static/warning/img/rtlogo.svg" alt="">
+            </a>
+        </div>
+    </div>
+    <div class="dropdown">
+        <div class="container">
+            <div class="wrapper">
+                <h1>Доступ ограничен</h1>
+                <p>Доступ к запрашиваемому ресурсу ограничен по решению суда или по иным основаниям,<br>установленным законодательством Российской Федерации</p>
+                <a href="#" class="dropdown-toggle">Возможные причины ограничения доступа</a>
+                <ol class="dropdown-menu">
+                    <li>Доступ ограничен по решению суда или по иным основаниям, установленным законодательством Российской Федерации.</li>
+                    <li>Указатель страницы и (или) доменное имя сайта, сетевой адрес включены в <a href="http://eais.rkn.gov.ru/" target="_blank">Единый Реестр</a> доменных имен, указателей страниц сайтов сети «Интернет» и сетевых адресов, позволяющих идентифицировать сайты в сети «Интернет», содержащие информацию, распространение которой в Российской Федерации запрещено.<br>Проверить наличие доменного имени и (или) указателя страницы сайта, сетевого адреса в Едином реестре можно в разделе<br>«Просмотр реестра» на сайте<a href="http://eais.rkn.gov.ru/" target="_blank">http://eais.rkn.gov.ru/</a></li>
+                    <li>Указатель страницы и (или) доменное имя, сетевой адрес включены в <a href="http://nap.rkn.gov.ru/" target="_blank">Реестр</a> доменных имен, указателей страниц сайтов в сети «Интернет» и сетевых адресов, позволяющих идентифицировать сайты в сети «Интернет», содержащие информацию, распространяемую с нарушением исключительных прав.<br>Проверить наличие доменного имени и (или) указателя страницы сайта, сетевого адреса в Реестре можно в разделе<br>«Просмотр реестра» на сайте<a href="http://nap.rkn.gov.ru/reestr/" target="_blank">http://nap.rkn.gov.ru/reestr/</a></li>
+                    <li>Указатель страницы и (или) доменное имя, сетевой адрес включены в <a href="http://398-fz.rkn.gov.ru/" target="_blank">Реестр</a> доменных имен, указателей страниц сайтов в сети «Интернет» и сетевых адресов, позволяющих идентифицировать сайты в сети «Интернет», содержащие призывы к массовым беспорядкам, осуществлению экстремистской деятельности, участию в массовых (публичных) мероприятиях, проводимых с нарушением установленного порядка.<br>Проверить наличие доменного имени и (или) указателя страницы сайта, сетевого адреса в Реестре можно в разделе<br>«Просмотр реестра» на сайте<a href="http://398-fz.rkn.gov.ru/" target="_blank">http://398-fz.rkn.gov.ru/</a></li>
+                    <li>Указатель страницы и (или) доменное имя включены в <a href="http://97-fz.rkn.gov.ru/" target="_blank">Реестр</a> организаторов распространения информации в сети «Интернет» и сайтов (или) страниц сайтов в сети «Интернет», на которых размещается общедоступная информация и доступ к которым в течение суток составляет более трех тысяч пользователей сети «Интернет».<br>Проверить наличие доменного имени и (или) указателя страницы сайта в Реестре можно в разделе «Просмотр реестра» на<br>сайте<a href="http://97-fz.rkn.gov.ru/" target="_blank">http://97-fz.rkn.gov.ru/</a></li>
+                </ol>
+            </div>
+        </div>
+    </div>
+    <a href="http://rt.ru/action/homeinternet/eset_5devices?utm_source=warningpage&utm_campaign=anitivirus&utm_content=esetna5" target="_blank"  class="container_anitivirus" id="anitivirus" style="display: none" data-goal-conversion-id="click_antivirus" data-goal-retargeting-id="show_antivirus"></a>
+     <a href="http://wg.rt.ru/?utm_source=warningpage&utm_campaign=gametarif&utm_content=tanki" target="_blank"  class="container_gt" id="game-tarif" style="display: none" data-goal-conversion-id="click_igr" data-goal-retargeting-id="show_tarif"></a>
+    <iframe id="games-rt" src="https://games.rt.ru/banned-frame" frameborder="0" width="100%" height="700" scrolling="no" style="display: none"></iframe>
+<!-- Switch Ad Blocks -->
+     <script>
+        (function(d, ids){
+            var l = ids.length, s = new Date().getTime() % 10, b;
+            if (s <= 3) {
+                b = 0;
+            } else if(s > 3 && s <= 7){
+                b = 1;
+            } else {
+                b = 2;
+            }
+            ids[b].goalId && RTKGoal([ids[b].goalId]);
+            for(var i = 0; i < l; i++) {
+                var el = d.getElementById(ids[i].elId)
+                if (i != b) {
+                    d.body.removeChild(el);
+                } else {
+                    el.style.display = ''
+                }
+            };
+        })(document, [{elId: 'game-tarif', goalId: 'show_tarif'}, {elId: 'games-rt', goalId: 'show_games'}, {elId: 'anitivirus', goalId:'show_antivirus'}]);
+    </script>
+    <!-- Switch Ad Blocks -->
+    <script>
+        if (typeof(UserAgentInfo) != 'undefined' && !window.addEventListener){
+            UserAgentInfo.strBrowser = 1;
+        }
+    </script>
+    <script type="text/javascript" src="./static/warning/js/jquery.min.js"></script>
+    <script type="text/javascript" src="./static/warning/js/main.js"></script>
+       
+
+    <!-- Sputnik counter -->
+    <script type="text/javascript">
+        (function(d, t, p) {
+            var j = d.createElement(t); j.async = true; j.type = "text/javascript";
+            j.src = ("https:" == p ? "https:" : "http:") + "//stat.sputnik.ru/cnt.js";
+            var s = d.getElementsByTagName(t)[0]; s.parentNode.insertBefore(j, s);
+        })(document, "script", document.location.protocol);
+    </script>
+    <!-- / Sputnik counter -->
+
+</body>
+</html>

--- a/af/oometa/009-simhash.install.sql
+++ b/af/oometa/009-simhash.install.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+select _v.register_patch( '009-simhash',  ARRAY[ '008-measurements-index' ], NULL );
+
+-- This table is empty, "inline" computation turned out to be as efficient as
+-- more complex scheme with caching of body_sha256 values that tried to avoid
+-- duplicate simhash computation. Moreover, inline storage is more efficient as
+-- it has no row overhead.
+
+DROP TABLE http_body_simhash;
+
+ALTER TABLE http_control
+    ADD COLUMN body_simhash bigint NULL,
+    ADD COLUMN body_text_simhash bigint NULL
+;
+
+ALTER TABLE http_request
+    ADD COLUMN body_simhash bigint NULL,
+    ADD COLUMN body_text_simhash bigint NULL
+;
+
+COMMIT;

--- a/af/shovel/Dockerfile
+++ b/af/shovel/Dockerfile
@@ -16,16 +16,9 @@ RUN set -ex \
     && git checkout -b build dc512f81f3d73069610ce33bb88abfff1fb2f96d \
     && python2.7 setup.py install --single-version-externally-managed --root=/ \
     && : \
-# Cython simhash, tag: v0.3.0, python-six is dependency, not build-dep
-    && git clone https://github.com/seomoz/simhash-py.git /var/tmp/simhash-py \
-    && cd /var/tmp/simhash-py \
-    && git checkout -b build 79bd4044f046c5542aee8e72849932f9e5d65403 \
-    && git submodule update --init --recursive \
-    && python2.7 setup.py install \
-    && : \
 # `pip` pollutes /root/.cache
     && apt-get install -y python-pip \
-    && pip install --system mmh3==2.3.1 \
+    && pip install --system mmh3==2.3.1 simhash-py=0.4.0 \
     && : \
 # awscli in ubuntu has a bug that triggers following error message in `aws s3 cp`:
 # upload failed: tmp/oo....yaml to s3://ooni-data/autoclaved/jsonl/2017-04-22/201...yaml seek() takes 2 positional arguments but 3 were given

--- a/af/shovel/Dockerfile
+++ b/af/shovel/Dockerfile
@@ -49,7 +49,6 @@ RUN set -ex \
     && :
 
 COPY canning.py daily_workflow.py autoclaving.py centrifugation.py originas2pg.py \
-    tor_log.py \
     aws_s3_ls.py \
     aws_s3_lz4cat_sync.py \
     cleanup_reports_raw.py \
@@ -60,5 +59,7 @@ COPY canning.py daily_workflow.py autoclaving.py centrifugation.py originas2pg.p
     canned_gzip_index.py \
     tar_reports_raw.py \
     /usr/local/bin/
+
+COPY oonipl /usr/local/lib/python2.7/dist-packages/oonipl
 
 USER daemon

--- a/af/shovel/autoclaving.py
+++ b/af/shovel/autoclaving.py
@@ -23,8 +23,10 @@ import yaml
 from yaml import CLoader # fail-fast if it's not built
 
 import canning
-from canning import ScopedPopen, PIPE, isomidnight, dirname, listdir_filesize
+from canning import listdir_filesize
 from daily_workflow import NormaliseReport, SanitiseReport
+from oonipl.cli import dirname, isomidnight
+from oonipl.popen import ScopedPopen, PIPE
 
 
 EPOCH = int(time.time()) # time to be stamped in produced tar files

--- a/af/shovel/aws_s3_lz4cat_sync.py
+++ b/af/shovel/aws_s3_lz4cat_sync.py
@@ -5,11 +5,10 @@ import gzip
 import json
 import os
 import re
-import shutil
-import tempfile
-from contextlib import contextmanager
 from datetime import datetime
 from subprocess import check_call, check_output
+
+from oonipl.tmp import ScopedTmpdir
 
 if datetime.fromtimestamp(0) != datetime(1970, 1, 1, 0, 0, 0):
     raise RuntimeError('awscli requires TZ=UTC')
@@ -21,14 +20,6 @@ def parse_args():
     p.add_argument('--s3-prefix', metavar='PREFIX', help='S3 bucket prefix to upload files to', required=True)
     opt = p.parse_args()
     return opt
-
-@contextmanager
-def ScopedTmpdir(*args, **kwargs):
-    tmpdir = tempfile.mkdtemp(*args, **kwargs)
-    try:
-        yield tmpdir
-    finally:
-        shutil.rmtree(tmpdir)
 
 def strip_prefix(s, prefix):
     l = len(prefix)

--- a/af/shovel/build
+++ b/af/shovel/build
@@ -1,2 +1,0 @@
-#!/bin/sh -x
-exec docker build -t openobservatory/shovel:0.0.19 -t openobservatory/shovel:latest .

--- a/af/shovel/canned_repeated.py
+++ b/af/shovel/canned_repeated.py
@@ -13,8 +13,10 @@ from subprocess import PIPE
 
 import psycopg2
 
-from canning import ScopedPopen, dirname, INDEX_FNAME
-from centrifugation import PGCopyFrom, pg_quote, pg_binquote
+from canning import INDEX_FNAME
+from oonipl.pg import PGCopyFrom, pg_quote, pg_binquote
+from oonipl.cli import dirname
+from oonipl.popen import ScopedPopen
 
 def get_repeated_sha1(files):
     # to avoid keeping 300Mb+ (and counting) in RAM

--- a/af/shovel/canning.py
+++ b/af/shovel/canning.py
@@ -18,9 +18,10 @@ import traceback
 from base64 import b64encode
 from contextlib import closing, contextmanager
 from hashlib import sha1
-from subprocess import Popen, PIPE
 from zlib import crc32 # btw, binascii.crc32 is four times slower than zlib.crc32
 
+from oonipl.cli import dirname, isomidnight
+from oonipl.popen import ScopedPopen, PIPE
 
 class CannerError(RuntimeError):
     pass
@@ -62,17 +63,6 @@ class Future(object):
         else:
             return self.retval
 
-
-@contextmanager
-def ScopedPopen(*args, **kwargs):
-    proc = Popen(*args, **kwargs)
-    try:
-        yield proc
-    finally:
-        try:
-            proc.kill()
-        except Exception:
-            pass
 
 
 class NopTeeFd(object):
@@ -457,26 +447,6 @@ def canning(input_root, output_root, bucket):
         os.link(fdindex.name, index_fpath)
     os.chmod(index_fpath, 0444)
     os.chmod(output_dir, 0555) # done!
-
-
-def isodatetime(s):
-    # Reverse of `datetime.isoformat()` besides microseconds & timezones
-    return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
-
-
-def isomidnight(s):
-    s = isodatetime(s)
-    if s.hour == s.minute == s.second == s.microsecond == 0:
-        return s
-    raise ValueError('isodatetime is not midnight-aligned', s)
-
-
-def dirname(s):
-    if not os.path.isdir(s):
-        raise ValueError('Not a directory', s)
-    if s[-1] == '/':
-        raise ValueError('Bogus trailing slash', s)
-    return s
 
 
 def parse_args():

--- a/af/shovel/centrifugation.py
+++ b/af/shovel/centrifugation.py
@@ -14,7 +14,6 @@ import sys
 import traceback
 from base64 import b64decode
 from contextlib import closing
-from cStringIO import StringIO
 from datetime import timedelta
 from itertools import groupby
 from operator import itemgetter
@@ -26,8 +25,10 @@ import simhash
 import ujson
 
 import autoclaving
-from canning import ChecksummingTee, NopTeeFd, isomidnight, dirname
-from tor_log import parse_tor_log
+from canning import ChecksummingTee, NopTeeFd
+from oonipl.tor_log import parse_tor_log
+from oonipl.cli import isomidnight, dirname
+from oonipl.pg import PGCopyFrom, pg_quote, pg_binquote, pg_uniquote
 
 # It does NOT take into account metadata tables right now:
 # - autoclaved: it's not obvious if anything can be updated there
@@ -158,180 +159,6 @@ def dns_ttl(ttl):
         raise RuntimeError('Invalid DNS TTL', ttl)
 
 ########################################################################
-
-PG_ARRAY_SPECIAL_RE = re.compile('[\t\x0a\x0b\x0c\x0d {},"\\\\]')
-BAD_UTF8_RE = re.compile( # https://stackoverflow.com/questions/18673213/detect-remove-unpaired-surrogate-character-in-python-2-gtk
-    ur'''(?x)            # verbose expression (allows comments)
-    (                    # begin group
-    [\ud800-\udbff]      #   match leading surrogate
-    (?![\udc00-\udfff])  #   but only if not followed by trailing surrogate
-    )                    # end group
-    |                    #  OR
-    (                    # begin group
-    (?<![\ud800-\udbff]) #   if not preceded by leading surrogate
-    [\udc00-\udfff]      #   match trailing surrogate
-    )                    # end group
-    |                    #  OR
-    \u0000
-    ''')
-
-def pg_uniquote(s):
-    if isinstance(s, str):
-        s = unicode(s, 'utf-8')
-    assert isinstance(s, unicode)
-    return BAD_UTF8_RE.sub(u'\ufffd', s) # `re` is smart enough to return same object in case of no-op
-
-def pg_quote(s):
-    # The following characters must be preceded by a backslash if they
-    # appear as part of a column value: backslash itself, newline, carriage
-    # return, and the current delimiter character.
-    # -- https://www.postgresql.org/docs/9.6/static/sql-copy.html
-    if isinstance(s, basestring):
-        # postgres requires UTF8, it's also unhappy about
-        # - unpaired surrogates https://www.postgresql.org/message-id/20060526134833.GC27513%40svana.org
-        #   example at 2016-04-01/http_requests.06.tar.lz4 | grep myfiona.co.kr
-        # - \u0000 as in ``DETAIL:  \u0000 cannot be converted to text.``
-        #   example at https://github.com/TheTorProject/ooni-pipeline/issues/65
-        if isinstance(s, str):
-            s = unicode(s, 'utf-8')
-        s = BAD_UTF8_RE.sub(u'\ufffd', s).encode('utf-8')
-        return s.replace('\\', '\\\\').replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
-    elif s is None:
-        return '\\N'
-    elif isinstance(s, bool): # WTF: assert isinstance(True, numbers.Number)!
-        return 'TRUE' if s else 'FALSE'
-    elif isinstance(s, numbers.Number):
-        return s
-    elif isinstance(s, list):
-        if all(isinstance(el, basestring) for el in s):
-            escaped = []
-            for el in s:
-                if PG_ARRAY_SPECIAL_RE.search(el):
-                    escaped.append('"' + el.replace('\\', '\\\\').replace('"', '\\"') + '"') # 8-[ ~ ]
-                else:
-                    escaped.append(el)
-            return pg_quote('{' + ','.join(escaped) + '}') # yes, once more!
-        elif all(isinstance(el, numbers.Number) for el in s):
-            return '{' + ','.join(map(str, s)) + '}'
-        else:
-            raise RuntimeError('Unable to quote list of unknown type', s)
-    else:
-        raise RuntimeError('Unable to quote unknown type', s)
-
-def pg_binquote(s):
-    assert isinstance(s, str)
-    return '\\\\x' + s.encode('hex')
-
-def pg_unquote(s):
-    if not isinstance(s, basestring):
-        raise RuntimeError('Unable to quote unknown type', s)
-    if s != '\\N':
-        return s.decode('string_escape') # XXX: gone in Python3
-    else:
-        return None
-
-class PGCopyFrom(object):
-    # Write buffer for COPY command to be able to COPY to several
-    # output tables over single postgres session. Alternative is to use several
-    # sessions and pipe data across threads with significant CPU overhead and
-    # inability to process every OONI measurement using set of functions to
-    # have clean "residual" document after data extraction.
-    def __init__(self, pgconn, table, badsink=None, wbufsize=2097152, **kwargs):
-        # default chunk size is taken as approx. cwnd between production VMs
-        self.__pgconn = pgconn
-        self.__table = table
-        self.__badsink = badsink
-        self.flush = self.__flush_easygoing if badsink is None else self.__flush_stubborn
-        self.__wbufsize = wbufsize
-        self.__kwargs = kwargs
-        self.__buf = StringIO()
-    def write(self, line):
-        assert len(line) == 0 or line[-1] == '\n'
-        pos = self.__buf.tell()
-        if pos > 0 and pos + len(line) > self.__wbufsize:
-            self.flush()
-        self.__buf.write(line)
-    def __flush_easygoing(self):
-        self.__buf.reset()
-        with self.__pgconn.cursor() as c:
-            c.copy_from(self.__buf, self.__table, **self.__kwargs)
-        self.__buf.reset()
-        self.__buf.truncate()
-    def __flush_stubborn(self):
-        self.__buf.seek(0, os.SEEK_END)
-        buf_size = self.__buf.tell()
-        bad_lines = []
-        base_line = 0
-        start_pos = 0
-        bad_size = 0
-        good_size = 0
-        eols = None
-        with self.__pgconn.cursor() as c:
-            while start_pos < buf_size:
-                self.__buf.seek(start_pos)
-                c.execute('SAVEPOINT flush_stubborn')
-                try:
-                    c.copy_from(self.__buf, self.__table, **self.__kwargs)
-                except (psycopg2.DataError, psycopg2.IntegrityError) as exc:
-                    m = re.search(r'\bCOPY {}, line (\d+)'.format(self.__table), exc.diag.context)
-                    if m is not None: # yes, it's best possible way to extract that datum :-(
-                        line = int(m.group(1)) - 1
-                        assert line >= 0
-                        line += base_line
-                        c.execute('ROLLBACK TO SAVEPOINT flush_stubborn')
-                    else:
-                        raise
-                else:
-                    line = None
-                c.execute('RELEASE SAVEPOINT flush_stubborn') # NB: ROLLBACK does not RELEASE, https://www.postgresql.org/message-id/1354145331.1766.84.camel%40sussancws0025
-                if line is None:
-                    self.__buf.truncate(start_pos)
-                    good_size += buf_size - start_pos
-                    start_pos = buf_size # to break the loop
-                else:
-                    if eols is None: # delay computation till error
-                        eols = list(m.end() for m in re.finditer('\n', self.__buf.getvalue()))
-                    start = eols[line-1] if line > 0 else 0
-                    end = eols[line]
-                    if bad_lines and bad_lines[-1][1] == start:
-                        start, _ = bad_lines.pop() # merge consequent bad lines
-                    bad_lines.append((start, end))
-                    assert end > start_pos
-                    start_pos = end
-                    base_line = line + 1
-            # __buf is either empty or ends with some bad lines now
-            if bad_lines:
-                for start, end in bad_lines:
-                    self.__buf.seek(start)
-                    bad = self.__buf.read(end - start)
-                    assert len(bad) == end - start
-                    self.__badsink.write(BadrowFeeder.badrow_row(self.__table, bad))
-                    bad_size += len(bad)
-                good_buf = StringIO()
-                # transforming bad_lines to good_lines
-                good_lines = list(sum(bad_lines, ()))
-                if good_lines[0] == 0: # first blob was bad
-                    good_lines.pop(0)
-                else: # first blob was good
-                    good_lines.insert(0, 0)
-                good_lines.pop() # last blob is always bad :)
-                for start, end in zip(good_lines[::2], good_lines[1::2]):
-                    self.__buf.seek(start)
-                    good_buf.write(self.__buf.read(end - start))
-                good_size += good_buf.tell()
-                if good_buf.tell():
-                    self.__buf = good_buf
-                    self.__flush_easygoing()
-                else:
-                    self.__buf.truncate(0)
-            assert good_size + bad_size == buf_size
-        assert self.__buf.tell() == 0
-    def close(self):
-        self.flush()
-        self.__buf.close()
-    @property
-    def closed(self):
-        return self.__buf.closed
 
 def load_autoclaved_index(autoclaved_index):
     # Returns: {filename: file_sha1 for autoclaved}
@@ -848,7 +675,8 @@ class BaseFeeder(object):
     def init_sink(self, pgconn, badsink=None):
         # It's rather convenient to initialize sink as a separate action as there are sinks
         # that have no explicit feeders, so all sinks should be a bit "separate".
-        self.sink = PGCopyFrom(pgconn, self.sink_table, columns=self.columns, badsink=badsink)
+        badrow_fmt = BadrowFeeder.badrow_row if badsink is not None else None
+        self.sink = PGCopyFrom(pgconn, self.sink_table, columns=self.columns, badsink=badsink, badrow_fmt=badrow_fmt)
         return self.sink
     def close(self):
         pass # assert self.sink.closed

--- a/af/shovel/centrifugation.py
+++ b/af/shovel/centrifugation.py
@@ -11,6 +11,7 @@ import numbers
 import os
 import re
 import sys
+import time
 import traceback
 from base64 import b64decode
 from contextlib import closing
@@ -29,20 +30,20 @@ from canning import ChecksummingTee, NopTeeFd
 from oonipl.tor_log import parse_tor_log
 from oonipl.cli import isomidnight, dirname
 from oonipl.pg import PGCopyFrom, pg_quote, pg_binquote, pg_uniquote
+from oonipl.sim import sim_shi4_mm3_layout, sim_shi4_mm3_text
 
 # It does NOT take into account metadata tables right now:
 # - autoclaved: it's not obvious if anything can be updated there
 # - report & measurement: have significant amount of metadata and may be actually updated eventually
 # Technically `http_headers` was added after CODE_VER=3, but bad headers were
 # causing bucket-wide exception, so re-import is not forced.
-CODE_VER = 4
+CODE_VER = 5
 
 CODE_VER_REPROCESS = 0 # special `code_ver` value to do partial re-processing
 
 FLAG_TRUE_TEMP = True # keep temporary tables if the flag is false
 FLAG_DEBUG_CHAOS = False # random fault injection
 FLAG_FAIL_FAST = False
-FLAG_SKIP_SIMHASH = True # it takes 75% of time, disable it for a while 
 assert not (FLAG_DEBUG_CHAOS and FLAG_FAIL_FAST), 'Absurd!'
 
 if FLAG_DEBUG_CHAOS:
@@ -51,23 +52,6 @@ if FLAG_DEBUG_CHAOS:
 # There are some reports that have duplicate report_id, same filename and same
 # content, there are ~500 of them by 2017-07-12. Some of them should be skipped.
 DUPLICATE_REPORTS = set()
-
-WORD_RE = re.compile('''[^\t\n\x0b\x0c\r !"#$%&\'()*+,-./:;<=>?@[\\\\\\]^_`{|}~']+''')
-
-def sim_shi4_mm3(text):
-    # NB: It makes quite little sense to use both 64bit numbers to compare
-    # hashes as pairwise Hamming distance using high 64bit is highly correlated
-    # with the distance computed using low 64bit. It's actually expected, but
-    # it means, that summing these distances is not linear and should be avoided.
-    # -- https://gist.github.com/darkk/e2b2762c4fe053a3cf8a299520f0490e
-    i1, i2 = itertools.tee(WORD_RE.finditer(text))
-    for _ in xrange(3): # 4 words per shingle
-        next(i2, None)
-    # mmh3.hash64 produces pairs of signed i64
-    # simhash.compute expects list of unsigned ui64 and produces unsigned ui64
-    mm = [mmh3.hash64(text[m1.start():m2.end()]) for m1, m2 in itertools.izip(i1, i2)]
-    return (simhash.compute([_[0] & 0xffffffffffffffff for _ in mm]),
-            simhash.compute([_[1] & 0xffffffffffffffff for _ in mm]))
 
 # NB: 30% of simtext2pg.py is spent here
 def to_signed(integer):
@@ -496,12 +480,6 @@ def prepare_destination(pgconn, stconn, bucket_code_ver):
     for feeder in (report, msm, msm_exc, badmeta):
         sink_list.append(feeder.init_sink(pgconn))
 
-    # `body` is dummy feeder to mimic feeder/sink protocol and be able to flush
-    # rows into DB while processing measurements one-by-one.
-    body = BodySimhashDummyFeeder()
-    body.sink = BodySimhashSink(stconn)
-    sink_list.append(body.sink)
-
     # badrow_sink does not need dummy feeder as `__flush_stubborn()` calls
     # write() explicitly and double fault just raises exception and aborts.
     badrow_sink = PGCopyFrom(pgconn, BadrowFeeder.sink_table, columns=BadrowFeeder.columns)
@@ -510,8 +488,8 @@ def prepare_destination(pgconn, stconn, bucket_code_ver):
     data_tables_args = {
         DnsFeeder: (pgconn,),
         HttpRequestFPFeeder: (pgconn,),
-        HttpRequestFeeder: (body.sink,),
-        HttpControlFeeder: (body.sink,),
+        HttpRequestFeeder: (),
+        HttpControlFeeder: (),
     }
     data_tables = {} # class -> feeder instance
     ver_feeders = {} # code_ver -> list of feeders
@@ -524,8 +502,6 @@ def prepare_destination(pgconn, stconn, bucket_code_ver):
                     sink_list.append(feeder.init_sink(pgconn, badrow_sink))
                     data_tables[cls] = feeder
                 flist.append(data_tables[cls])
-        if HttpRequestFeeder in flist or HttpControlFeeder in flist:
-            flist.append(body)
         ver_feeders[ver] = flist
 
     # `badrow_sink` has to be created before `data_tables` feeders, but
@@ -533,7 +509,7 @@ def prepare_destination(pgconn, stconn, bucket_code_ver):
     sink_list.append(badrow_sink)
 
     feeder_list = list(data_tables.values())
-    feeder_list.extend((body, badmeta, msm_exc, msm, report))
+    feeder_list.extend((badmeta, msm_exc, msm, report))
 
     return report, msm, msm_exc, badmeta, ver_feeders, sink_list, feeder_list
 
@@ -624,6 +600,7 @@ def iter_autoclaved_datum(pgconn, autoclaved_root, bucket):
         ''', [bucket, CODE_VER])
         for (filename, file_size, file_crc32, file_sha1), itfile in groupby(cmeta, itemgetter(0, 1, 2, 3)):
             print 'Processing autoclaved {}'.format(filename)
+            begin = time.time() # time.monotonic() is Python 3.5+
             with open(os.path.join(autoclaved_root, filename)) as fd:
                 fd = ChecksummingTee(fd, NopTeeFd)
                 for (frame_off, frame_size), itframe in groupby(itfile, itemgetter(4, 5)):
@@ -640,6 +617,9 @@ def iter_autoclaved_datum(pgconn, autoclaved_root, bucket):
                         yield code_ver, autoclaved_no, report_no, msm_no, datum
                 for _ in iter(functools.partial(fd.read, 4096), ''):
                     pass # skip till EOF
+                real = time.time() - begin
+                size_mib = fd.size / (2. ** 20)
+                print "Processed {}: {:.1f} MiB, {:.1f} s, {:.1f} MiB/s".format(filename, size_mib, real, size_mib / real)
                 db_cksum = (file_size, file_crc32, str(file_sha1)) # file_sha1 is returned as buffer()
                 fd_cksum = (fd.size, fd.crc32, fd.sha1)
                 if db_cksum != fd_cksum:
@@ -1064,83 +1044,6 @@ class DnsFeeder(BaseFeeder):
         del self.pgconn
 
 
-class BodySimhashDummyFeeder(object):
-    fake_row = object()
-    @staticmethod
-    def row(msm_no, datum):
-        return BodySimhashDummyFeeder.fake_row
-    @staticmethod
-    def close():
-        pass
-
-class BodySimhashSink(object):
-    # NB: this data goes to small-transaction connection (stconn) to be
-    # available to other nodes as soon as it's commited.
-    # Queue is buffered to avoid round-trip to database for every webpage.
-    # Computation is delayed till filling the database as it's rather
-    # expensive, throughput is ~7.5 Mbytes/s, so roundtrip to DB is done to
-    # exclude already parsed pages. It's unclear if extra roundtrip makes sense
-    # when known_sha256 cache is used.
-    # Average body size is 75kb and cross-report cachehit is ~18%.
-    fake_row = object()
-    def __init__(self, stconn):
-        self.stconn = stconn
-        self.known_sha256 = IsKnownL2(85000, 15000)
-        self.queue = {}
-        self.known = 0
-        self.size = 0
-    def put(self, body_sha256, body):
-        if FLAG_SKIP_SIMHASH:
-            return
-        assert isinstance(body_sha256, str) and isinstance(body, str)
-        if self.known_sha256.is_known(body_sha256): # either in DB or in queue
-            self.known += 1
-            return
-        self.queue[body_sha256] = body
-        self.size += len(body)
-        # `write()` is not called from `put()` to have clean place to raise
-        # exception from, as there are several places calling `put()` guardede
-        # by TrappedException and exception in `flush()` should be fatal.
-    def write(self, row):
-        assert row is BodySimhashDummyFeeder.fake_row
-        if self.size > 16777216 or len(self.queue) > 2048:
-            self.flush()
-    def flush(self):
-        with self.stconn, self.stconn.cursor() as c:
-            # NB: https://www.datadoghq.com/blog/100x-faster-postgres-performance-by-changing-1-line/ when postgres < 9.3
-            c.execute('SELECT body_sha256 FROM http_body_simhash WHERE body_sha256 = ANY(%s)',
-                [map(psycopg2.Binary, self.queue.iterkeys())])
-            just_fetched = [str(_[0]) for _ in c]
-            for body_sha256 in just_fetched:
-                del self.queue[body_sha256]
-            args = []
-            for body_sha256, body in self.queue.iteritems():
-                hi, lo = sim_shi4_mm3(body)
-                hi, lo = to_signed(hi), to_signed(lo)
-                args.append(psycopg2.Binary(body_sha256)) # http://initd.org/psycopg/docs/usage.html#binary-adaptation
-                args.append(hi)
-                args.append(lo)
-            assert len(args) % 3 == 0
-            if len(args):
-                c.execute('INSERT INTO http_body_simhash (body_sha256, simhash_shi4mm3hi, simhash_shi4mm3lo) VALUES {} '
-                          'ON CONFLICT DO NOTHING RETURNING body_sha256'.format(
-                          ', '.join(['(%s, %s, %s)'] * (len(args) / 3))),
-                          args)
-                just_inserted = {_[0] for _ in c}
-            else:
-                just_inserted = {}
-            print 'BodySimhashSink: skipped {:d} queue {:d} pre-filter {:d} db-dup {:d}'.format(
-                    self.known,
-                    len(self.queue) + len(just_fetched),
-                    len(just_fetched),
-                    len(self.queue) - len(just_inserted))
-        self.queue.clear()
-        self.known = 0
-        self.size = 0
-    def close(self):
-        self.flush()
-        del self.stconn, self.queue, self.known_sha256
-
 class VanillaTorFeeder(BaseFeeder):
     min_compat_code_ver = 4
     data_table = sink_table = 'vanilla_tor'
@@ -1215,17 +1118,15 @@ def get_title(body):
     return title
 
 class BaseHttpFeeder(BaseFeeder):
-    def __init__(self, body_sink):
-        self.body_sink = body_sink
-    def body_sha256(self, body):
+    def pg_body_hash(self, body):
         if body is not None:
-            body_sha256 = hashlib.sha256(body)
-            digest = body_sha256.digest()
-            self.body_sink.put(digest, body)
-            body_sha256 = pg_binquote(digest)
+            body_sha256 = pg_binquote(hashlib.sha256(body).digest())
+            body_simhash = sim_shi4_mm3_layout(body)
+            body_text_simhash = sim_shi4_mm3_text(body)
         else:
             body_sha256 = pg_quote(None)
-        return body_sha256
+            body_simhash = body_text_simhash = pg_quote(None)
+        return body_sha256, body_simhash, body_text_simhash
     COMMON_HEADERS = {
         'Accept-Language': 'en-US;q=0.8,en;q=0.5',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
@@ -1250,9 +1151,10 @@ class BaseHttpFeeder(BaseFeeder):
                 tor.pop('exit_name')
 
 class HttpControlFeeder(BaseHttpFeeder):
-    min_compat_code_ver = 2
+    min_compat_code_ver = 5
     data_table = sink_table = 'http_control'
-    columns = ('msm_no', 'is_tor', 'failure', 'status_code', 'body_length', 'title', 'headers', 'body_sha256')
+    columns = ('msm_no', 'is_tor', 'failure', 'status_code', 'body_length', 'title', 'headers',
+               'body_sha256', 'body_simhash', 'body_text_simhash')
     def row(self, msm_no, datum):
         ret = ''
         if datum['test_name'] == 'web_connectivity':
@@ -1265,7 +1167,7 @@ class HttpControlFeeder(BaseHttpFeeder):
                 body_length = r.get('body_length')
                 if body_length == -1:
                     body_length = None
-                ret = '{:d}\tFALSE\t{}\t{}\t{}\t{}\t{}\t\\N\n'.format(
+                ret = '{:d}\tFALSE\t{}\t{}\t{}\t{}\t{}\t\\N\t\\N\t\\N\n'.format(
                         msm_no,
                         pg_quote(r['failure']),
                         pg_quote(http_status_code(status_code)),
@@ -1277,20 +1179,22 @@ class HttpControlFeeder(BaseHttpFeeder):
                 if r['request']['tor']['is_tor']:
                     response = r['response']
                     body = httpt_body(response)
-                    body_sha256 = self.body_sha256(body)
+                    body_sha256, body_simhash, body_text_simhash = self.pg_body_hash(body)
                     if response is None:
                         response = {}
                     headers = response.get('headers')
                     if headers is not None:
                         headers = ujson.dumps(http_headers(headers))
-                    ret += '{:d}\tTRUE\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
+                    ret += '{:d}\tTRUE\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
                         msm_no,
                         pg_quote(r.get('failure')),
                         pg_quote(http_status_code(response.get('code'))),
                         pg_quote(len(body) if body is not None else r.get('response_length')),
                         pg_quote(get_title(body)),
                         pg_quote(headers),
-                        body_sha256)
+                        body_sha256,
+                        body_simhash,
+                        body_text_simhash)
         return ret
     def pop(self, datum):
         if datum['test_name'] == 'web_connectivity':
@@ -1317,9 +1221,10 @@ class HttpControlFeeder(BaseHttpFeeder):
 
 
 class HttpRequestFeeder(BaseHttpFeeder):
-    min_compat_code_ver = 2
+    min_compat_code_ver = 5
     data_table = sink_table = 'http_request'
-    columns = ('msm_no', 'url', 'failure', 'status_code', 'body_length', 'title', 'headers', 'body_sha256')
+    columns = ('msm_no', 'url', 'failure', 'status_code', 'body_length', 'title', 'headers',
+               'body_sha256', 'body_simhash', 'body_text_simhash')
     def row(self, msm_no, datum):
         ret = ''
         if datum['test_name'] == 'web_connectivity':
@@ -1335,13 +1240,13 @@ class HttpRequestFeeder(BaseHttpFeeder):
     def _row(self, msm_no, r):
         response = r['response']
         body = httpt_body(response)
-        body_sha256 = self.body_sha256(body)
+        body_sha256, body_simhash, body_text_simhash = self.pg_body_hash(body)
         if response is None: # may be `null` both for web_connectivity and http_requests
             response = {}
         headers = response.get('headers')
         if headers is not None:
             headers = ujson.dumps(http_headers(headers))
-        return '{:d}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
+        return '{:d}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n'.format(
             msm_no,
             pg_quote(r['request']['url']),
             pg_quote(r.get('failure')),
@@ -1349,7 +1254,9 @@ class HttpRequestFeeder(BaseHttpFeeder):
             pg_quote(len(body) if body is not None else r.get('response_length')),
             pg_quote(get_title(body)),
             pg_quote(headers),
-            body_sha256)
+            body_sha256,
+            body_simhash,
+            body_text_simhash)
     def pop(self, datum):
         if datum['test_name'] == 'web_connectivity':
             for r in datum['test_keys']['requests']:
@@ -1502,30 +1409,6 @@ DATA_TABLES = (
     HttpRequestFPFeeder,
     HttpVerdictFeeder,
 )
-
-class IsKnownL2(object):
-    # Fixed-size in-memory set to check if some object is "known".
-    # Two-layer Random-Replacement cache improves efficiency
-    # measurably compared to one-big Random-Replacement cache.
-    def __init__(self, l1, l2):
-        self.__l1 = set()
-        self.__l2 = set()
-        self.__l1len = l1
-        self.__l2len = l2
-    def is_known(self, key):
-        l1, l2 = self.__l1, self.__l2
-        if key in l2:
-            return True
-        if key in l1:
-            l1.remove(key)
-            l2.add(key)
-            if len(l2) > self.__l2len:
-                l2.pop() # FIXME: not quite random element
-            return True
-        l1.add(key)
-        if len(l1) > self.__l1len:
-            l1.pop() # not quite random element
-        return False
 
 def meta_pg(in_root, bucket, postgres):
     assert in_root[-1] != '/' and '/' not in bucket and os.path.isdir(os.path.join(in_root, bucket))

--- a/af/shovel/check_sanitised.py
+++ b/af/shovel/check_sanitised.py
@@ -20,7 +20,7 @@ import ujson
 import lz4.frame as lz4frame
 
 import autoclaving
-from canning import dirname
+from oonipl.cli import dirname
 
 FILE_START, FILE_END, REPORT_START, REPORT_END, BADBLOB, DATUM = object(), object(), object(), object(), object(), object()
 

--- a/af/shovel/cleanup_reports_raw.py
+++ b/af/shovel/cleanup_reports_raw.py
@@ -6,13 +6,9 @@ import gzip
 import json
 import os
 
-from canning import dirname, load_verified_index, listdir_filesize
-
-def json_gz(fname):
-    return json.load(gzip.GzipFile(fname))
-
-def jsonl_gz(fname):
-    return map(json.loads, gzip.GzipFile(fname))
+from canning import load_verified_index, listdir_filesize
+from oonipl.cli import dirname
+from oonipl.jsonz import jsonl_gz, json_gz
 
 def cleanup_reports_raw(reports_raw_root, bucket, texts):
     dirname = os.path.join(reports_raw_root, bucket)

--- a/af/shovel/cleanup_sanitised.py
+++ b/af/shovel/cleanup_sanitised.py
@@ -9,9 +9,10 @@ import json
 import os
 
 import autoclaving
-from canning import dirname, listdir_filesize
+from canning import listdir_filesize
 from check_sanitised import calc_santoken
 from cleanup_reports_raw import s3_ls_jsongz
+from oonipl.cli import dirname
 
 def cleanup_sanitised(sanitised_root, autoclaved_root, bucket, s3_ls):
     if 'public/sanitised/' not in s3_ls['metadata']['url']:

--- a/af/shovel/cleanup_uploaded.py
+++ b/af/shovel/cleanup_uploaded.py
@@ -4,8 +4,8 @@
 import argparse
 import os
 
-from canning import dirname
-from cleanup_reports_raw import json_gz
+from oonipl.cli import dirname
+from oonipl.jsonz import json_gz
 
 def filename(s):
     if not os.path.isfile(s):

--- a/af/shovel/oonipl/__init__.py
+++ b/af/shovel/oonipl/__init__.py
@@ -1,0 +1,2 @@
+# perl code of OONI written in python
+# ... because it's possible to write perl code in any language!

--- a/af/shovel/oonipl/cli.py
+++ b/af/shovel/oonipl/cli.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import os
+import datetime
+
+def dirname(s):
+    if not os.path.isdir(s):
+        raise ValueError('Not a directory', s)
+    if s[-1] == '/':
+        raise ValueError('Bogus trailing slash', s)
+    return s
+
+def isodatetime(s):
+    # Reverse of `datetime.isoformat()` besides microseconds & timezones
+    return datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S')
+
+def isomidnight(s):
+    s = isodatetime(s)
+    if s.hour == s.minute == s.second == s.microsecond == 0:
+        return s
+    raise ValueError('isodatetime is not midnight-aligned', s)

--- a/af/shovel/oonipl/jsonz.py
+++ b/af/shovel/oonipl/jsonz.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+# It's not named `json.py` to avoid obvious conflict with `json` module.
+
+import json
+import gzip
+
+def json_gz(fname):
+    return json.load(gzip.GzipFile(fname))
+
+def jsonl_gz(fname):
+    return map(json.loads, gzip.GzipFile(fname))

--- a/af/shovel/oonipl/pg.py
+++ b/af/shovel/oonipl/pg.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import numbers
+import os
+import re
+from cStringIO import StringIO
+
+import psycopg2
+
+class PGCopyFrom(object):
+    # Write buffer for COPY command to be able to COPY to several
+    # output tables over single postgres session. Alternative is to use several
+    # sessions and pipe data across threads with significant CPU overhead and
+    # inability to process every OONI measurement using set of functions to
+    # have clean "residual" document after data extraction.
+    def __init__(self, pgconn, table, badsink=None, badrow_fmt=None, wbufsize=2097152, **kwargs):
+        # default chunk size is taken as approx. cwnd between production VMs
+        self.__pgconn = pgconn
+        self.__table = table
+        self.__badsink = badsink
+        self.__badrow_fmt = badrow_fmt # callback(table_name, copy_from_row_text_for_table) -> copy_from_row_text_for_badsink
+        self.flush = self.__flush_easygoing if badsink is None else self.__flush_stubborn
+        self.__wbufsize = wbufsize
+        self.__kwargs = kwargs
+        self.__buf = StringIO()
+    def write(self, line):
+        assert len(line) == 0 or line[-1] == '\n'
+        pos = self.__buf.tell()
+        if pos > 0 and pos + len(line) > self.__wbufsize:
+            self.flush()
+        self.__buf.write(line)
+    def __flush_easygoing(self):
+        self.__buf.reset()
+        with self.__pgconn.cursor() as c:
+            c.copy_from(self.__buf, self.__table, **self.__kwargs)
+        self.__buf.reset()
+        self.__buf.truncate()
+    def __flush_stubborn(self):
+        self.__buf.seek(0, os.SEEK_END)
+        buf_size = self.__buf.tell()
+        bad_lines = []
+        base_line = 0
+        start_pos = 0
+        bad_size = 0
+        good_size = 0
+        eols = None
+        with self.__pgconn.cursor() as c:
+            while start_pos < buf_size:
+                self.__buf.seek(start_pos)
+                c.execute('SAVEPOINT flush_stubborn')
+                try:
+                    c.copy_from(self.__buf, self.__table, **self.__kwargs)
+                except (psycopg2.DataError, psycopg2.IntegrityError) as exc:
+                    m = re.search(r'\bCOPY {}, line (\d+)'.format(self.__table), exc.diag.context)
+                    if m is not None: # yes, it's best possible way to extract that datum :-(
+                        line = int(m.group(1)) - 1
+                        assert line >= 0
+                        line += base_line
+                        c.execute('ROLLBACK TO SAVEPOINT flush_stubborn')
+                    else:
+                        raise
+                else:
+                    line = None
+                c.execute('RELEASE SAVEPOINT flush_stubborn') # NB: ROLLBACK does not RELEASE, https://www.postgresql.org/message-id/1354145331.1766.84.camel%40sussancws0025
+                if line is None:
+                    self.__buf.truncate(start_pos)
+                    good_size += buf_size - start_pos
+                    start_pos = buf_size # to break the loop
+                else:
+                    if eols is None: # delay computation till error
+                        eols = list(m.end() for m in re.finditer('\n', self.__buf.getvalue()))
+                    start = eols[line-1] if line > 0 else 0
+                    end = eols[line]
+                    if bad_lines and bad_lines[-1][1] == start:
+                        start, _ = bad_lines.pop() # merge consequent bad lines
+                    bad_lines.append((start, end))
+                    assert end > start_pos
+                    start_pos = end
+                    base_line = line + 1
+            # __buf is either empty or ends with some bad lines now
+            if bad_lines:
+                for start, end in bad_lines:
+                    self.__buf.seek(start)
+                    bad = self.__buf.read(end - start)
+                    assert len(bad) == end - start
+                    self.__badsink.write(self.__badrow_fmt(self.__table, bad))
+                    bad_size += len(bad)
+                good_buf = StringIO()
+                # transforming bad_lines to good_lines
+                good_lines = list(sum(bad_lines, ()))
+                if good_lines[0] == 0: # first blob was bad
+                    good_lines.pop(0)
+                else: # first blob was good
+                    good_lines.insert(0, 0)
+                good_lines.pop() # last blob is always bad :)
+                for start, end in zip(good_lines[::2], good_lines[1::2]):
+                    self.__buf.seek(start)
+                    good_buf.write(self.__buf.read(end - start))
+                good_size += good_buf.tell()
+                if good_buf.tell():
+                    self.__buf = good_buf
+                    self.__flush_easygoing()
+                else:
+                    self.__buf.truncate(0)
+            assert good_size + bad_size == buf_size
+        assert self.__buf.tell() == 0
+    def close(self):
+        self.flush()
+        self.__buf.close()
+    @property
+    def closed(self):
+        return self.__buf.closed
+
+BAD_UTF8_RE = re.compile( # https://stackoverflow.com/questions/18673213/detect-remove-unpaired-surrogate-character-in-python-2-gtk
+    ur'''(?x)            # verbose expression (allows comments)
+    (                    # begin group
+    [\ud800-\udbff]      #   match leading surrogate
+    (?![\udc00-\udfff])  #   but only if not followed by trailing surrogate
+    )                    # end group
+    |                    #  OR
+    (                    # begin group
+    (?<![\ud800-\udbff]) #   if not preceded by leading surrogate
+    [\udc00-\udfff]      #   match trailing surrogate
+    )                    # end group
+    |                    #  OR
+    \u0000
+    ''')
+
+PG_ARRAY_SPECIAL_RE = re.compile('[\t\x0a\x0b\x0c\x0d {},"\\\\]')
+
+def pg_quote(s):
+    # The following characters must be preceded by a backslash if they
+    # appear as part of a column value: backslash itself, newline, carriage
+    # return, and the current delimiter character.
+    # -- https://www.postgresql.org/docs/9.6/static/sql-copy.html
+    if isinstance(s, basestring):
+        # postgres requires UTF8, it's also unhappy about
+        # - unpaired surrogates https://www.postgresql.org/message-id/20060526134833.GC27513%40svana.org
+        #   example at 2016-04-01/http_requests.06.tar.lz4 | grep myfiona.co.kr
+        # - \u0000 as in ``DETAIL:  \u0000 cannot be converted to text.``
+        #   example at https://github.com/TheTorProject/ooni-pipeline/issues/65
+        if isinstance(s, str):
+            s = unicode(s, 'utf-8')
+        s = BAD_UTF8_RE.sub(u'\ufffd', s).encode('utf-8')
+        return s.replace('\\', '\\\\').replace('\n', '\\n').replace('\r', '\\r').replace('\t', '\\t')
+    elif s is None:
+        return '\\N'
+    elif isinstance(s, bool): # WTF: assert isinstance(True, numbers.Number)!
+        return 'TRUE' if s else 'FALSE'
+    elif isinstance(s, numbers.Number):
+        return s
+    elif isinstance(s, list):
+        if all(isinstance(el, basestring) for el in s):
+            escaped = []
+            for el in s:
+                if PG_ARRAY_SPECIAL_RE.search(el):
+                    escaped.append('"' + el.replace('\\', '\\\\').replace('"', '\\"') + '"') # 8-[ ~ ]
+                else:
+                    escaped.append(el)
+            return pg_quote('{' + ','.join(escaped) + '}') # yes, once more!
+        elif all(isinstance(el, numbers.Number) for el in s):
+            return '{' + ','.join(map(str, s)) + '}'
+        else:
+            raise RuntimeError('Unable to quote list of unknown type', s)
+    else:
+        raise RuntimeError('Unable to quote unknown type', s)
+
+def _pg_unquote(s): # is used only in the test
+    if not isinstance(s, basestring):
+        raise RuntimeError('Unable to quote unknown type', s)
+    if s != '\\N':
+        return s.decode('string_escape') # XXX: gone in Python3
+    else:
+        return None
+
+def pg_binquote(s):
+    assert isinstance(s, str)
+    return '\\\\x' + s.encode('hex')
+
+def pg_uniquote(s):
+    if isinstance(s, str):
+        s = unicode(s, 'utf-8')
+    assert isinstance(s, unicode)
+    return BAD_UTF8_RE.sub(u'\ufffd', s) # `re` is smart enough to return same object in case of no-op

--- a/af/shovel/oonipl/popen.py
+++ b/af/shovel/oonipl/popen.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+from subprocess import Popen, PIPE
+from contextlib import contextmanager
+
+@contextmanager
+def ScopedPopen(*args, **kwargs):
+    proc = Popen(*args, **kwargs)
+    try:
+        yield proc
+    finally:
+        try:
+            proc.kill()
+        except Exception:
+            pass

--- a/af/shovel/oonipl/sim.py
+++ b/af/shovel/oonipl/sim.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import itertools
+import re
+
+import mmh3
+import simhash
+
+WORD_RE = re.compile('''[^\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./:;<=>?@[\\\\\\]^_`{|}~']+''')
+NONTEXT_RE = re.compile('''[\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&\'()*+,-./:;<=>?@[\\\\\\]^_`{|}~']+''')
+SPACE_RE = re.compile('[\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f ]+')
+
+# 1. HTML comment may contain anything
+# 2. javascript may contain style in a string
+# 3. css is probably not that mad
+# 4. tags are not that important
+# So the order to strip them is outlined abouve :-)
+HTML_COMMENT_RE = re.compile(r'<!--.*?-->', re.IGNORECASE | re.DOTALL)
+SCRIPT_RE = re.compile(r'<\s*script\s*[^>]*>.*?</\s*script\s*>', re.IGNORECASE | re.DOTALL)
+STYLE_RE = re.compile(r'<\s*style\s*[^>]*>.*?</\s*style\s*>', re.IGNORECASE | re.DOTALL)
+HTML_ENTITIES_RE = re.compile(r'&#?[xX]?(?:[0-9a-fA-F]+|\w{1,8})[;\s]')
+HTML_TAGS_RE = re.compile(r'<.*?>', re.IGNORECASE | re.DOTALL)
+
+# NB: It makes little sense to use both 64bit numbers from MurmurHash3 to compare
+# hashes as pairwise Hamming distance using high 64bit is highly correlated
+# with the distance computed using low 64bit. It's actually expected, but
+# it means, that summing these distances is not linear and should be avoided.
+# -- https://gist.github.com/darkk/e2b2762c4fe053a3cf8a299520f0490e
+
+# mmh3.hash64 produces pairs of signed i64
+# simhash.compute expects list of unsigned ui64 and produces unsigned ui64
+# postgres has signed i64, so it's converted back
+
+def sim_shi4_mm3_layout(text):
+    text = SPACE_RE.sub(' ', text) # replace all runs of spaces
+
+    i1, i2 = itertools.tee(WORD_RE.finditer(text))
+    for _ in xrange(3): # 4 words per shingle
+        next(i2, None)
+
+    hash64 = mmh3.hash64
+    # NB: `array` of i64 & ui64 is Python 3.3+
+    mm = [hash64(text[m1.start():m2.end()])[0] & 0xffffffffffffffff
+          for m1, m2 in itertools.izip(i1, i2)]
+    r = simhash.compute(mm)
+    return r - 0x10000000000000000 if r > 0x7fffffffffffffff else r
+
+def sim_shi4_mm3_text(text):
+    text = HTML_COMMENT_RE.sub(' ', text)
+    text = SCRIPT_RE.sub(' ', text)
+    text = STYLE_RE.sub(' ', text)
+    text = HTML_TAGS_RE.sub(' ', text)
+    text = HTML_ENTITIES_RE.sub(' ', text)
+    text = NONTEXT_RE.sub(' ', text) # replace all runs of spaces and punctuation
+
+    i1, i2 = itertools.tee(WORD_RE.finditer(text))
+    for _ in xrange(3): # 4 words per shingle
+        next(i2, None)
+
+    hash64 = mmh3.hash64
+    # NB: `array` of i64 & ui64 is Python 3.3+
+    mm = [hash64(text[m1.start():m2.end()])[0] & 0xffffffffffffffff
+          for m1, m2 in itertools.izip(i1, i2)]
+    r = simhash.compute(mm)
+    return r - 0x10000000000000000 if r > 0x7fffffffffffffff else r

--- a/af/shovel/oonipl/tmp.py
+++ b/af/shovel/oonipl/tmp.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+
+import shutil
+import tempfile
+from contextlib import contextmanager
+
+@contextmanager
+def ScopedTmpdir(*args, **kwargs):
+    tmpdir = tempfile.mkdtemp(*args, **kwargs)
+    try:
+        yield tmpdir
+    finally:
+        shutil.rmtree(tmpdir)

--- a/af/shovel/oonipl/tor_log.py
+++ b/af/shovel/oonipl/tor_log.py
@@ -1,4 +1,5 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
 
 import re
 

--- a/af/shovel/tar_reports_raw.py
+++ b/af/shovel/tar_reports_raw.py
@@ -10,8 +10,9 @@ import time
 
 from contextlib import closing
 
-from canning import dirname, load_verified_index, listdir_filesize, stream_canning
-from aws_s3_lz4cat_sync import ScopedTmpdir
+from canning import load_verified_index, listdir_filesize, stream_canning
+from oonipl.cli import dirname
+from oonipl.tmp import ScopedTmpdir
 
 def filelist_from_canndx(canned_index):
     filelist = []

--- a/af/shovel/test_centrifugation.py
+++ b/af/shovel/test_centrifugation.py
@@ -17,7 +17,8 @@ from base64 import b64encode
 
 import psycopg2
 
-from centrifugation import httpt_body, PGCopyFrom, pg_quote, pg_unquote, exc_hash, pop_values, ChecksummingTee, NopTeeFd
+from centrifugation import httpt_body, exc_hash, pop_values, ChecksummingTee, NopTeeFd
+from oonipl.pg import PGCopyFrom, pg_quote, _pg_unquote
 
 
 def _httpt_body(body, te=None):
@@ -57,12 +58,12 @@ class TestPGQuoting(unittest.TestCase):
         self.assertEqual(pg_quote(False), 'FALSE')
     def test_bits(self):
         blob = u''.join(map(unichr, xrange(1, 256))).encode('utf-8')
-        self.assertEqual(blob, pg_unquote(pg_quote(blob)))
+        self.assertEqual(blob, _pg_unquote(pg_quote(blob)))
         self.assertEqual(u'\ufffd'.encode('utf-8'), pg_quote(u'\u0000'))
         self.assertEqual(u'\ufffd'.encode('utf-8'), pg_quote('\0'))
     def test_ugly(self):
         blob = r'\\n'
-        self.assertEqual(blob, pg_unquote(pg_quote(blob)))
+        self.assertEqual(blob, _pg_unquote(pg_quote(blob)))
 
 PG = os.getenv('UNITTEST_PG')
 

--- a/af/shovel/test_centrifugation.py
+++ b/af/shovel/test_centrifugation.py
@@ -182,7 +182,7 @@ class TestPartialReprocessing(unittest.TestCase):
         acroot, bucket = '/srv/autoclaved', '2017-08-28'
         with self.conn, self.conn.cursor() as c:
             # almost every table besides `fingerprint`
-            c.execute('TRUNCATE TABLE autoclaved, badmeta, badrow, dns_a, domain, http_body_simhash, http_control, http_request, http_request_fp, http_verdict, input, label, measurement, report, residual, software, tcp, vanilla_tor')
+            c.execute('TRUNCATE TABLE autoclaved, badmeta, badrow, dns_a, domain, http_control, http_request, http_request_fp, http_verdict, input, label, measurement, report, residual, software, tcp, vanilla_tor')
 
         files, modify, add = self.take_part_of_bucket(acroot, bucket)
 


### PR DESCRIPTION
It'll enable heuristics that rely on page similarity to mine more blockpages our of existing OONI dataset.

Draft implementation included non-trivial caching scheme that was trying to avoid unnecessary computation of simhashes for known body_sha256 values. It turned out that the complexity of the code was providing not that much benefits for the modern state of OONI data.  There are still ~30% of perfectly same pages coming from different probes, but runtime de-duplication takes as much real time as computing hashes, moreover, existing code took non-trivial amount of RAM (over 512M) for computation.

Here are approximate relative numbers of wall clock time needed to ingest a bucket of OONI data:

No simhash           &mdash; 1.0
Old simhash          &mdash; 4.8
New simhash(body)    &mdash; 4.7
Same + simhash(text) &mdash; 6.0

Current bucket ingestion takes 40...80 minutes, so it'll become 4..8 hours. That's still okay as it's single-CPU and can easily utilize SMP when it'll be needed.

An open problem is re-ingestion of data stored in http_control and http_request tables as it'll include re-computation of all the simhashes without any good reason.

So the de-duplication code is dropped and simhashes are stored together with body_sha256.