### PR TITLE
Ingest new metadata in fastpath for blocking detection

### DIFF
--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -776,6 +776,53 @@ def score_tcp_connect(msm) -> dict:
     return scores
 
 
+def score_dash(msm) -> dict:
+    """Calculate measurement scoring for DASH
+    (Dynamic Adaptive Streaming over HTTP)
+    Returns a scores dict
+    """
+    # TODO: review scores
+    # TODO: any blocking scoring based on performance?
+    scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
+    failure = msm["test_keys"].get("failure", None)
+    if failure == None:
+        pass
+    elif failure == "connection_aborted":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "json_parse_error":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "eof_error":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "json_processing_error":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "http_request_failed":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "connect_error":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "generic_timeout_error":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "broken_pipe":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif failure == "connection_refused":
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    elif "ssl_error" in failure:
+        scores["blocking_general"] = 0.1
+        scores["accuracy"] = 0.0
+    else:
+        scores["msg"] = "Probe error"
+        scores["accuracy"] = 0.0
+
+    return scores
+
 
 
 @metrics.timer("score_measurement")
@@ -802,6 +849,8 @@ def score_measurement(msm, matches) -> dict:
         return score_ndt(msm)
     if tn == "tcp_connect":
         return score_tcp_connect(msm)
+    if tn == "dash":
+        return score_dash(msm)
 
     log.debug("Unsupported test name %s", tn)
     return {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}

--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -733,6 +733,51 @@ def score_web_connectivity(msm, matches) -> dict:
     return scores
 
 
+@metrics.timer("score_ndt")
+def score_ndt(msm) -> dict:
+    """Calculate measurement scoring for NDT
+    Returns a scores dict
+    """
+    # TODO: this is just a stub - add NDT scoring where possible
+    return {}
+
+
+@metrics.timer("score_tcp_connect")
+def score_tcp_connect(msm) -> dict:
+    """Calculate measurement scoring for tcp connect
+    Returns a scores dict
+    """
+    # TODO: review scores
+    scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
+    tk = msm["test_keys"]
+    assert msm["input"]
+    conn_result = tk.get("connection", None)
+
+    if conn_result == "success":
+        return scores
+
+    if conn_result == "generic_timeout_error":
+        scores["blocking_general"] = 0.8
+        return scores
+
+    if conn_result == "connection_refused_error":
+        scores["blocking_general"] = 0.8
+        return scores
+
+    if conn_result == "connect_error":
+        scores["blocking_general"] = 0.8
+        return scores
+
+    if conn_result == "tcp_timed_out_error":
+        scores["blocking_general"] = 0.8
+        return scores
+
+    scores["blocking_general"] = 1.0
+    return scores
+
+
+
+
 @metrics.timer("score_measurement")
 def score_measurement(msm, matches) -> dict:
     """Calculate measurement scoring. Returns a scores dict
@@ -751,9 +796,12 @@ def score_measurement(msm, matches) -> dict:
         return score_measurement_whatsapp(msm)
     if tn == "vanilla_tor":
         return score_vanilla_tor(msm)
-
     if tn == "web_connectivity":
         return score_web_connectivity(msm, matches)
+    if tn == "ndt":
+        return score_ndt(msm)
+    if tn == "tcp_connect":
+        return score_tcp_connect(msm)
 
     log.debug("Unsupported test name %s", tn)
     return {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}

--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -863,6 +863,20 @@ def score_meek_fronted_requests_test(msm) -> dict:
     return scores
 
 
+def score_psiphon(msm) -> dict:
+    """Calculate measurement scoring for Psiphon
+    Returns a scores dict
+    """
+    scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
+    rid = msm["report_id"]
+    tk = msm["test_keys"]
+    if "resolver_ip" not in tk:
+        log.debug("client_bug: no resolver_ip in %s", rid)
+        scores["accuracy"] = 0.0
+
+    return scores
+
+
 @metrics.timer("score_measurement")
 def score_measurement(msm, matches) -> dict:
     """Calculate measurement scoring. Returns a scores dict
@@ -891,6 +905,8 @@ def score_measurement(msm, matches) -> dict:
         return score_dash(msm)
     if tn == "meek_fronted_requests_test":
         return score_meek_fronted_requests_test(msm)
+    if tn == "psiphon":
+        return score_psiphon(msm)
 
     log.debug("Unsupported test name %s", tn)
     return {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}

--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -356,7 +356,7 @@ def match_fingerprints(measurement):
     return matches
 
 
-def truekeys(d, keys):
+def all_keys_true(d, keys):
     """Check for values set to True in a dict"""
     if isinstance(keys, str):
         keys = (keys,)
@@ -367,7 +367,7 @@ def truekeys(d, keys):
     return True
 
 
-def falsekeys(d, keys):
+def all_keys_false(d, keys):
     """Check for values set to True in a dict"""
     if isinstance(keys, str):
         keys = (keys,)
@@ -378,7 +378,7 @@ def falsekeys(d, keys):
     return True
 
 
-def nonekeys(d, keys):
+def all_keys_none(d, keys):
     """Check for values set to None in a dict"""
     if isinstance(keys, str):
         keys = (keys,)
@@ -447,7 +447,7 @@ def score_measurement_facebook_messenger(msm):
         "facebook_star_reachable",
         "facebook_stun_dns_consistent",
     )
-    if truekeys(tk, trues) and falsekeys(tk, "facebook_tcp_blocking"):
+    if all_keys_true(tk, trues) and all_keys_false(tk, "facebook_tcp_blocking"):
         score = 0
 
     else:
@@ -692,7 +692,7 @@ def score_vanilla_tor(msm):
     scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
 
     nks = ("error", "success", "tor_log", "tor_progress_summary", "tor_progress_tag")
-    if msm["software_name"] == "ooniprobe" and nonekeys(tk, nks):
+    if msm["software_name"] == "ooniprobe" and all_keys_none(tk, nks):
         if tk["tor_progress"] == 0:
             # client bug?
             scores["msg"] = "Client bug"

--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -355,6 +355,7 @@ def match_fingerprints(measurement):
 
     return matches
 
+
 @metrics.timer("score_measurement_facebook_messenger")
 def score_measurement_facebook_messenger(msm, summary):
     tk = msm["test_keys"]
@@ -364,25 +365,22 @@ def score_measurement_facebook_messenger(msm, summary):
     # If the value of these keys is false (inconsistent) there is something
     # fishy
     consistency_keys = [
-        'facebook_b_api_dns_consistent',
-        'facebook_b_api_reachable',
-        'facebook_b_graph_dns_consistent',
-        'facebook_b_graph_reachable',
-        'facebook_edge_dns_consistent',
-        'facebook_edge_reachable',
-        'facebook_external_cdn_dns_consistent',
-        'facebook_external_cdn_reachable',
-        'facebook_scontent_cdn_dns_consistent',
-        'facebook_scontent_cdn_reachable',
-        'facebook_star_dns_consistent',
-        'facebook_star_reachable',
-        'facebook_stun_dns_consistent'
+        "facebook_b_api_dns_consistent",
+        "facebook_b_api_reachable",
+        "facebook_b_graph_dns_consistent",
+        "facebook_b_graph_reachable",
+        "facebook_edge_dns_consistent",
+        "facebook_edge_reachable",
+        "facebook_external_cdn_dns_consistent",
+        "facebook_external_cdn_reachable",
+        "facebook_scontent_cdn_dns_consistent",
+        "facebook_scontent_cdn_reachable",
+        "facebook_star_dns_consistent",
+        "facebook_star_reachable",
+        "facebook_stun_dns_consistent",
     ]
     # These are keys that if they are true it means there is something fishy
-    anomaly_keys = [
-        'facebook_tcp_blocking',
-        'facebook_dns_blocking'
-    ]
+    anomaly_keys = ["facebook_tcp_blocking", "facebook_dns_blocking"]
 
     scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
     s = 0
@@ -490,6 +488,7 @@ def score_measurement_telegram(msm, summary):
     summary["scores"] = scores
     return summary
 
+
 @metrics.timer("score_measurement_hhfm")
 def score_measurement_hhfm(msm, summary):
     tk = msm["test_keys"]
@@ -497,15 +496,15 @@ def score_measurement_hhfm(msm, summary):
     s = 0
     scores = {f"blocking_{l}": 0.0 for l in LOCALITY_VALS}
 
-    exp_req_headers = tk['requests'][0].get('request', {}).get('headers', {})
+    exp_req_headers = tk["requests"][0].get("request", {}).get("headers", {})
     # We add this as it's not explicitly included in the data from the probe
     # although it is actually sent
-    exp_req_headers['Connection'] = 'close'
-    exp_req_failure = tk['requests'][0].get('failure', None)
+    exp_req_headers["Connection"] = "close"
+    exp_req_failure = tk["requests"][0].get("failure", None)
 
     exp_resp_body = None
     if exp_req_failure is None:
-        exp_resp_body = tk['requests'][0]['response'].get('body', None)
+        exp_resp_body = tk["requests"][0]["response"].get("body", None)
     else:
         s += 0.5
 
@@ -523,12 +522,12 @@ def score_measurement_hhfm(msm, summary):
         s += 1
 
     if ctrl_headers:
-        if len(exp_req_headers) != len(ctrl_headers['headers_dict']):
+        if len(exp_req_headers) != len(ctrl_headers["headers_dict"]):
             headers_modified = True
             s += 1
         for k, v in exp_req_headers.items():
             try:
-                if v != ctrl_headers['headers_dict'][k][0]:
+                if v != ctrl_headers["headers_dict"][k][0]:
                     headers_modified = True
             except KeyError:
                 s += 0.5
@@ -539,6 +538,7 @@ def score_measurement_hhfm(msm, summary):
     scores["blocking_general"] = s
     summary["scores"] = scores
     return summary
+
 
 @metrics.timer("score_measurement_whatsapp")
 def score_measurement_whatsapp(msm, summary):

--- a/af/fastpath/fastpath/db.py
+++ b/af/fastpath/fastpath/db.py
@@ -54,7 +54,7 @@ def setup(conf) -> None:
 
 
 @metrics.timer("upsert_summary")
-def upsert_summary(msm, summary, tid, filename, update):
+def upsert_summary(msm, scores, tid, filename, update):
     """Insert a row in the fastpath_scores table. Overwrite an existing one.
     """
     sql_base_tpl = """
@@ -93,7 +93,7 @@ def upsert_summary(msm, summary, tid, filename, update):
         msm["measurement_start_time"],
         platform,
         filename,
-        Json(summary["scores"], dumps=ujson.dumps),
+        Json(scores, dumps=ujson.dumps),
     )
 
     cols = (
@@ -117,7 +117,7 @@ def upsert_summary(msm, summary, tid, filename, update):
 
         notification = {k: msm[k] for k in cols}
         notification["trivial_id"] = tid
-        notification["scores"] = summary["scores"]
+        notification["scores"] = scores
         notification = ujson.dumps(notification)
         q = f"SELECT pg_notify('fastpath', '{notification}');"
         cur.execute(q)

--- a/af/fastpath/fastpath/pytest.ini
+++ b/af/fastpath/fastpath/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+norecursedirs = dist doc build .tox .eggs
+filterwarnings =
+    ignore::DeprecationWarning:botocore
+
+    # Using or importing the ABCs from 'collections'...
+    ignore::DeprecationWarning:socks
+
+    # remove once https://github.com/pytest-dev/pytest-cov/issues/327 is released
+    ignore::pytest.PytestWarning:pytest_cov

--- a/af/fastpath/fastpath/pytest.ini
+++ b/af/fastpath/fastpath/pytest.ini
@@ -8,3 +8,6 @@ filterwarnings =
 
     # remove once https://github.com/pytest-dev/pytest-cov/issues/327 is released
     ignore::pytest.PytestWarning:pytest_cov
+
+# Disable unused plugins
+addopts = -p no:xonsh -p no:forked

--- a/af/fastpath/fastpath/s3feeder.py
+++ b/af/fastpath/fastpath/s3feeder.py
@@ -40,12 +40,14 @@ for l in ("urllib3", "botocore", "s3transfer"):
     logging.getLogger(l).setLevel(logging.INFO)
 
 
-def load_multiple(fn) -> dict:
+def load_multiple(fn, touch=True) -> tuple:
     """Load contents of cans. Decompress tar archives if found.
     Yields measurements one by one as:
         (string of JSON, None) or (None, msmt dict)
     """
-    os.utime(fn)  # update access time - used for cache cleanup
+    if touch:
+        os.utime(fn)  # update access time - used for cache cleanup
+
     # TODO: handle:
     # RuntimeError: LZ4F_decompress failed with code: ERROR_decompressionFailed
     if fn.endswith(".tar.lz4"):

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -13,6 +13,7 @@ import boto3  # debdeps: python3-boto3
 import pytest  # debdeps: python3-pytest
 
 import fastpath.core as fp
+import fastpath.s3feeder as s3feeder
 
 # from fastpath.utils import fingerprints
 
@@ -35,6 +36,10 @@ def cans():
     _cans = dict(
         it="2018-05-07/20180501T071932Z-IT-AS198471-web_connectivity-20180506T090836Z_AS198471_gKqEpbg0Ny30ldGCQockbZMJSg9HhFiSizjey5e6JxSEHvzm7j-0.2.0-probe.json.lz4",
         cn="2018-05-07/20180506T014008Z-CN-AS4134-web_connectivity-20180506T014010Z_AS4134_ZpxhAVt3iqCjT5bW5CfJspbqUcfO4oZfzDVjCWAu2UuVkibFsv-0.2.0-probe.json.lz4",
+        telegram="2019-08-29/telegram.0.tar.lz4",
+        # telegram="2019-08-29/20190829T105210Z-IR-AS31549-telegram-20190829T105214Z_AS31549_t32ZZ5av3B6yNruRIFhCnuT1dHTnwPk7vwIa9F0TAe064HG4tk-0.2.0-probe.json",
+        # whatsapp="2019-06-15/20190615T070248Z-ET-AS24757-whatsapp-20190615T070253Z_AS24757_gRi6dhAqgWa7Yp4tah4LX6Rl1j6c8kJuja3OgZranEpMicEj2p-0.2.0-probe.json",
+        # fb="2019-06-27/20190627T214121Z-ET-AS24757-facebook_messenger-20190627T214126Z_AS24757_h8g9P5kTmmzyX1VyOjqcVonIbFNujm84l2leMCwC2gX3BI78fI-0.2.0-probe.json",
     )
     for k, v in _cans.items():
         _cans[k] = Path("testdata") / v
@@ -76,3 +81,70 @@ def setup_module(module):
     fp.conf.cachedir = fp.conf.vardir / "cache"
     fp.conf.s3cachedir = fp.conf.cachedir / "s3"
     fp.conf.sshcachedir = fp.conf.cachedir / "ssh"
+
+
+def test_telegram(cans):
+    can = cans["telegram"]
+    for measurement_tup in s3feeder.load_multiple(can.as_posix()):
+        msm_jstr, msm = measurement_tup
+        if msm is None:
+            msm = ujson.loads(msm_jstr)
+        summary = fp.score_measurement(msm, [])
+        # fmt: off
+        if (msm["report_id"] == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0"):
+            assert summary["scores"] == {
+                "blocking_general": 1.5,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+                "web_failure": None,
+                "accessible_endpoints": 10,
+                "unreachable_endpoints": 0,
+                "http_success_cnt": 0,
+                "http_failure_cnt": 0,
+            }, msm
+
+        elif (msm["report_id"] == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r"):
+            assert summary["scores"] == {
+                "blocking_general": 1.0,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+                "web_failure": "connection_reset",
+                "accessible_endpoints": 10,
+                "unreachable_endpoints": 0,
+                "http_success_cnt": 10,
+                "http_failure_cnt": 0,
+                "msg": "Telegam failure: connection_reset",
+            }
+        elif (msm["report_id"] == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM"):
+            assert summary["scores"] == {
+                "blocking_general": 3.0,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+                "web_failure": "generic_timeout_error",
+                "accessible_endpoints": 0,
+                "unreachable_endpoints": 10,
+                "http_success_cnt": 0,
+                "http_failure_cnt": 10,
+                "msg": "Telegam failure: generic_timeout_error",
+            }
+        elif (msm["report_id"] == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz"):
+            assert summary["scores"] == {
+                "blocking_general": 3.0,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+                "web_failure": "connect_error",
+                "accessible_endpoints": 0,
+                "unreachable_endpoints": 10,
+                "http_success_cnt": 0,
+                "http_failure_cnt": 10,
+                "msg": "Telegam failure: connect_error",
+            }
+        # fmt: on

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -3,6 +3,7 @@ Simulate feeding from the collectors or cans on S3 using a local can
 """
 # Format with black -t py37 -l 120
 
+from collections import Counter
 from pathlib import Path
 import logging
 import os
@@ -42,6 +43,10 @@ def cans():
         # telegram="2019-08-29/20190829T105210Z-IR-AS31549-telegram-20190829T105214Z_AS31549_t32ZZ5av3B6yNruRIFhCnuT1dHTnwPk7vwIa9F0TAe064HG4tk-0.2.0-probe.json",
         # whatsapp="2019-06-15/20190615T070248Z-ET-AS24757-whatsapp-20190615T070253Z_AS24757_gRi6dhAqgWa7Yp4tah4LX6Rl1j6c8kJuja3OgZranEpMicEj2p-0.2.0-probe.json",
         # fb="2019-06-27/20190627T214121Z-ET-AS24757-facebook_messenger-20190627T214126Z_AS24757_h8g9P5kTmmzyX1VyOjqcVonIbFNujm84l2leMCwC2gX3BI78fI-0.2.0-probe.json",
+        hhfm_2019_10_26="2019-10-26/http_header_field_manipulation.0.tar.lz4",
+        hhfm_2019_10_27="2019-10-27/http_header_field_manipulation.0.tar.lz4",
+        hhfm_2019_10_28="2019-10-28/http_header_field_manipulation.0.tar.lz4",
+        hhfm_2019_10_29="2019-10-29/http_header_field_manipulation.0.tar.lz4",
     )
     for k, v in _cans.items():
         _cans[k] = Path("testdata") / v
@@ -76,6 +81,7 @@ def list_cans_on_s3_for_a_day(day, filter=None):
         if filter is None or (filter in fn):
             print(fn, size)
 
+
 def disabled_test_list_cans():
     """Used for debugging"""
     list_cans_on_s3_for_a_day("2019-10-27", "header_field_manipulation")
@@ -84,6 +90,7 @@ def disabled_test_list_cans():
     list_cans_on_s3_for_a_day("2019-10-30", "header_field_manipulation")
     list_cans_on_s3_for_a_day("2019-10-31", "header_field_manipulation")
     assert 0
+
 
 def log_obj(o):
     log.info(ujson.dumps(o, sort_keys=True, ensure_ascii=False, indent=2))
@@ -142,10 +149,7 @@ def test_telegram(cans):
     can = cans["telegram"]
     for msm in load_can(can):
         scores = fp.score_measurement(msm, [])
-        if (
-            msm["report_id"]
-            == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0"
-        ):
+        if msm["report_id"] == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0":
             assert scores == {
                 "blocking_general": 1.5,
                 "blocking_global": 0.0,
@@ -159,10 +163,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
             }, msm
 
-        elif (
-            msm["report_id"]
-            == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r"
-        ):
+        elif msm["report_id"] == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r":
             assert scores == {
                 "blocking_general": 1.0,
                 "blocking_global": 0.0,
@@ -176,10 +177,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
                 "msg": "Telegam failure: connection_reset",
             }
-        elif (
-            msm["report_id"]
-            == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM"
-        ):
+        elif msm["report_id"] == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM":
             assert scores == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
@@ -193,10 +191,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 10,
                 "msg": "Telegam failure: generic_timeout_error",
             }
-        elif (
-            msm["report_id"]
-            == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz"
-        ):
+        elif msm["report_id"] == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz":
             assert scores == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
@@ -217,10 +212,7 @@ def test_whatsapp(cans):
     debug = False
     for msm in load_can(can):
         scores = fp.score_measurement(msm, [])
-        if (
-            msm["report_id"]
-            == "20190830T002828Z_AS209_fDHPMTveZ66kGmktmW8JiGDgqAJRivgmBkZjAVRmFbH92OIlTX"
-        ):
+        if msm["report_id"] == "20190830T002828Z_AS209_fDHPMTveZ66kGmktmW8JiGDgqAJRivgmBkZjAVRmFbH92OIlTX":
             assert scores == {
                 "blocking_general": 0.8,
                 "blocking_global": 0.0,
@@ -229,10 +221,7 @@ def test_whatsapp(cans):
                 "blocking_local": 0.0,
             }, msm
 
-        if (
-            msm["report_id"]
-            == "20190829T002541Z_AS29119_kyaEYabRxQW6q41n4kPH9aX5cvFEXNheCj1fguSf4js3JydUbr"
-        ):
+        if msm["report_id"] == "20190829T002541Z_AS29119_kyaEYabRxQW6q41n4kPH9aX5cvFEXNheCj1fguSf4js3JydUbr":
             # The probe is reporting a false positive: due to the empty client headers
             # it hits https://www.whatsapp.com/unsupportedbrowser
             print_msm(msm)
@@ -256,16 +245,10 @@ def test_facebook_messenger(cans):
     debug = False
     for msm in load_can(can):
         scores = fp.score_measurement(msm, [])
-        if (
-            msm["report_id"]
-            != "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC"
-        ):
+        if msm["report_id"] != "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC":
             continue
 
-        if (
-            msm["report_id"]
-            == "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC"
-        ):
+        if msm["report_id"] == "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC":
             # not blocked
             assert scores == {
                 "blocking_general": 0.0,
@@ -291,10 +274,7 @@ def test_facebook_messenger_bug(cans):
     can = cans["facebook_messenger"]
     for msm in load_can(can):
         scores = fp.score_measurement(msm, [])
-        if (
-            msm["report_id"]
-            != "20190829T000015Z_AS137_6FCvPkYvOAPUqKgO8QdllyWXTPXUbUAVV3cA43E6drE0KAe4iO"
-        ):
+        if msm["report_id"] != "20190829T000015Z_AS137_6FCvPkYvOAPUqKgO8QdllyWXTPXUbUAVV3cA43E6drE0KAe4iO":
             continue
 
         assert scores == {
@@ -314,18 +294,12 @@ def test_facebook_messenger_newer(cans):
         scores = fp.score_measurement(msm, [])
         rid = msm["report_id"]
 
-        if (
-            rid
-            == "20191029T101630Z_AS56040_bBOkNtg65fMfH0iOHiG8lMk4UmERxjfJL20ki33lKlyKjS0FkP"
-        ):
+        if rid == "20191029T101630Z_AS56040_bBOkNtg65fMfH0iOHiG8lMk4UmERxjfJL20ki33lKlyKjS0FkP":
             # TCP really blocked
             assert scores["blocking_general"] >= 1.0
             continue
 
-        elif (
-            rid
-            == "20191029T020948Z_AS50010_ZUPoP3hOdwazqZnzPurdWgfLvoMcDL1qyOHHFtEtISjNWMgkrX"
-        ):
+        elif rid == "20191029T020948Z_AS50010_ZUPoP3hOdwazqZnzPurdWgfLvoMcDL1qyOHHFtEtISjNWMgkrX":
             # DNS returns mostly 0.0.0.0 - but one connection succeeds
             assert scores["blocking_general"] >= 1.0
             continue
@@ -353,3 +327,90 @@ def test_facebook_messenger_newer(cans):
 
     # Everything around DNS looks broken but TCP is OK
     # https://explorer.ooni.org/measurement/20191029T213318Z_AS1257_DA3tEqiSVtfOllWDIXcw6KVJdit0TX9Tiv8y2Xganhlx2iWzzh
+
+
+def test_score_measurement_hhfm_large(cans):
+    debug = False
+    for d in range(26, 30):
+        can = cans["hhfm_2019_10_{}".format(d)]
+        for msm in load_can(can):
+            rid = msm["report_id"]
+            scores = fp.score_measurement(msm, [])
+            if rid == "20191028T115649Z_AS28573_eIrzDM4njwMjxBi0ODrerI5N03zM7qQoCvl4xpapTccdW0kCRg":
+                # Missing the "requests" field
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191027T103751Z_AS0_A7vlqt3Ju8pmWflPxJ3E9NyrWJX47yYzQFJcSw63RBDtDm5ulf":
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191027T143046Z_AS35540_5j5W6Q9Iz2pvVNaBtn2heKVHRDzuPtKNcLfrIhVHTmrgA7kWaT":
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191027T192636Z_AS55430_DXpEUz925f3BS7UWyMPnXL8g8OtyDIF3FArF2z9h1ILMtrc":
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191027T002012Z_AS45595_p2qNg0FmL4d2kIuLQXEn36MbraErPPA5i64eE1e6nLfGluHpLk":
+                # Client bug?
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191027T192636Z_AS55430_DXpEUz925f3BS7UWyMPnXL8g8OtyDIF3FArF2z9h1ILMtrcbyb":
+                # Success - response code 200
+                assert scores["blocking_general"] == 0, scores
+
+            elif rid == "20191029T231841Z_AS1257_sGsZRCxZ8obOSLCVCLppeUSfu1La481EQ6E6MGkGBTgffJBs6t":
+                # x-tele2-subid was injected
+                assert scores["blocking_general"] > 0, scores
+                assert scores["msg"] == "1 unexpected header change"
+
+            elif rid == "20191029T071035Z_AS45629_wwVlbw7hc1jJaP5tBfzICM8S4dBhPJK29V97YzJLpthft1Zo6z":
+                # Proxy injecting 3 headers
+                assert scores["blocking_general"] > 0, scores
+
+            elif debug and scores["blocking_general"] == 1.1:
+                url = "https://explorer.ooni.org/measurement/{}".format(rid)
+                print(msm["test_start_time"], msm["probe_cc"], url, msm["test_keys"]["requests"][0].get("failure", None))
+                print_msm(msm)
+                print(scores)
+
+
+def disabled_test_score_measurement_hhfm_stats(cans):
+
+    can = cans["hhfm_2019_10_27"]
+    # Distribution of request->failure values in this can
+    #
+    # connection_refused 599
+    # connection_refused_error 144
+    # connection_reset 67
+    # None 29
+    # eof_error 18
+    # generic_timeout_error 4
+    # response_never_received 4
+    # network_unreachable 2
+    # connect_error 1
+    # Total 868
+
+    d = Counter()  # CC:failure type -> count
+    s = Counter()  # failure type -> count
+    for n, msm in enumerate(load_can(can)):
+        rid = msm["report_id"]
+        # scores = fp.score_measurement(msm, [])
+        cc = msm["probe_cc"]
+        fm = msm["test_keys"]["requests"][0].get("failure", "*************")
+        if fm is None:
+            print_msm(msm)
+        url = "https://explorer.ooni.org/measurement/{}".format(rid)
+        print(url)
+        print(
+            msm["probe_cc"],
+            msm["test_keys"]["requests"][0].get("failure", None),
+        )
+
+        d.update(("{}:{}".format(cc, fm),))
+        s.update((fm,))
+
+    #for i, c in d.most_common(120):
+    #    print(i, c)
+    for i, c in s.most_common(120):
+        print(i, c)
+    print("Total", sum(s.values()))
+    assert 0

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -123,7 +123,7 @@ def _print_msm_node(n, depth=0):
             v = n[k]
             if k == "body":
                 print("{}{}".format(ind, "body: ..."))
-            #elif k == "tor_log":
+            # elif k == "tor_log":
             #    print("{}{}".format(ind, "tor_log: ..."))
             elif isinstance(v, list) or isinstance(v, dict):
                 print("{}{}:".format(ind, k))
@@ -328,7 +328,6 @@ def test_facebook_messenger_newer(cans):
         elif scores["blocking_general"] > 0:
             blocked_cnt += 1
             if debug:
-                print(msm["probe_cc"], msm["software_name"], msm["software_version"])
                 print_msm(msm)
                 print(scores)
 
@@ -389,7 +388,9 @@ def test_score_measurement_hhfm_large(cans):
 
             elif debug and scores["blocking_general"] == 1.1:
                 url = "https://explorer.ooni.org/measurement/{}".format(rid)
-                print(msm["test_start_time"], msm["probe_cc"], url, msm["test_keys"]["requests"][0].get("failure", None))
+                print(
+                    msm["test_start_time"], msm["probe_cc"], url, msm["test_keys"]["requests"][0].get("failure", None)
+                )
                 print_msm(msm)
                 print(scores)
 
@@ -421,15 +422,12 @@ def disabled_test_score_measurement_hhfm_stats(cans):
             print_msm(msm)
         url = "https://explorer.ooni.org/measurement/{}".format(rid)
         print(url)
-        print(
-            msm["probe_cc"],
-            msm["test_keys"]["requests"][0].get("failure", None),
-        )
+        print(msm["probe_cc"], msm["test_keys"]["requests"][0].get("failure", None))
 
         d.update(("{}:{}".format(cc, fm),))
         s.update((fm,))
 
-    #for i, c in d.most_common(120):
+    # for i, c in d.most_common(120):
     #    print(i, c)
     for i, c in s.most_common(120):
         print(i, c)
@@ -465,16 +463,16 @@ def test_score_vanilla_tor(cans):
             if rid == "20191029T012425Z_AS45194_So00Y296Ve6q1TvjOtKqsvH1ieiVF566PlcUUOw4Ia37HGPwPL":
                 # timeout
                 assert scores["blocking_general"] > 0
-                blocked_cnt +=1
+                blocked_cnt += 1
                 total_score += scores["blocking_general"]
 
             elif scores["blocking_general"] > 0:
-                blocked_cnt +=1
+                blocked_cnt += 1
                 total_score += scores["blocking_general"]
-                #print("https://explorer.ooni.org/measurement/{}".format(rid))
-                #print_msm(msm)
-                #print(scores)
-                #assert 0
+                # print("https://explorer.ooni.org/measurement/{}".format(rid))
+                # print_msm(msm)
+                # print(scores)
+                # assert 0
 
     p = blocked_cnt * 100 / cnt
     assert 0.35 < p < 0.36, p
@@ -555,24 +553,19 @@ def test_score_tcp_connect(cans):
 def test_score_dash(cans):
     # rid -> blocking_general, accuracy
     expected = {
-        "20191026T015105Z_AS4837_7vwBtbVmZZqwZhdTHnqHan0Nwa7bi7TeJ789htG3RB91C3eyU1":
-        (0.1, 0.0, "blocking_general"),
-        "20191026T022317Z_AS17380_ZJGnXdvHl4j1M4xTeskrGhC8SW1KT4buJEjxCsTagCGO2NZeAD":
-        (0.1, 0.0, "json_parse_error"),
-        "20191026T032159Z_AS20057_xLjBSrTyZjOn6C7pa5BPyUxyBhzWHbSooKQjUY9zcWADnkakIR":
-        (0.1, 0.0, "eof_error"),
-        "20191026T051350Z_AS44244_9yjPG1UbgIjtAFg9LiTUxVhq7hGuG3tG4yMnvt6gRJTaFdQme6":
-        (0.1, 0.0, "json_processing_error"),
-        "20191026T071332Z_AS7713_caK9GNyp9ZhN7zL9cg2dg0zGhs44CwHmxZtOyK7B6rBKRaGGMF":
-        (0.1, 0.0, "http_request_failed"),
-        "20191026T093003Z_AS4837_yHZ0f8Oxyhus9vBKAUa0tA2XMSObIO0frShG6YBieBzY9RiSBg":
-        (0.1, 0.0, "connect_error"),
-        "20191026T165434Z_AS0_qPbZHZF8VXUWgzlvqT9Jd7ARuHSl2Dq4tPcEq580rgYZGmV5Um":
-        (0.1, 0.0, "generic_timeout_error"),
-        "20191028T160112Z_AS1640_f4zyjjp5vFcwZkAKPrTokayPRdcXPfdEMRbdo1LmIaLZRile6P":
-        (0.1, 0.0, "broken_pipe"),
-        "20191029T094043Z_AS49048_qGQxBh6lv26TOfuWfhGcUtz2LZWwboXlfbh058CSF1fOmEUv6Z":
-        (0.1, 0.0, "connection_refused"),
+        "20191026T015105Z_AS4837_7vwBtbVmZZqwZhdTHnqHan0Nwa7bi7TeJ789htG3RB91C3eyU1": (0.1, 0.0, "blocking_general"),
+        "20191026T022317Z_AS17380_ZJGnXdvHl4j1M4xTeskrGhC8SW1KT4buJEjxCsTagCGO2NZeAD": (0.1, 0.0, "json_parse_error"),
+        "20191026T032159Z_AS20057_xLjBSrTyZjOn6C7pa5BPyUxyBhzWHbSooKQjUY9zcWADnkakIR": (0.1, 0.0, "eof_error"),
+        "20191026T051350Z_AS44244_9yjPG1UbgIjtAFg9LiTUxVhq7hGuG3tG4yMnvt6gRJTaFdQme6": (
+            0.1,
+            0.0,
+            "json_processing_error",
+        ),
+        "20191026T071332Z_AS7713_caK9GNyp9ZhN7zL9cg2dg0zGhs44CwHmxZtOyK7B6rBKRaGGMF": (0.1, 0.0, "http_request_failed"),
+        "20191026T093003Z_AS4837_yHZ0f8Oxyhus9vBKAUa0tA2XMSObIO0frShG6YBieBzY9RiSBg": (0.1, 0.0, "connect_error"),
+        "20191026T165434Z_AS0_qPbZHZF8VXUWgzlvqT9Jd7ARuHSl2Dq4tPcEq580rgYZGmV5Um": (0.1, 0.0, "generic_timeout_error"),
+        "20191028T160112Z_AS1640_f4zyjjp5vFcwZkAKPrTokayPRdcXPfdEMRbdo1LmIaLZRile6P": (0.1, 0.0, "broken_pipe"),
+        "20191029T094043Z_AS49048_qGQxBh6lv26TOfuWfhGcUtz2LZWwboXlfbh058CSF1fOmEUv6Z": (0.1, 0.0, "connection_refused"),
     }
     for d in range(26, 30):
         can = cans["dash_2019_10_{}".format(d)]

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -69,6 +69,22 @@ def cans():
     return _cans
 
 
+def list_cans_on_s3_for_a_day(day, filter=None):
+    s3 = s3feeder.create_s3_client()
+    fns = s3feeder.list_cans_on_s3_for_a_day(s3, day)
+    for fn, size in sorted(fns):
+        if filter is None or (filter in fn):
+            print(fn, size)
+
+def disabled_test_list_cans():
+    """Used for debugging"""
+    list_cans_on_s3_for_a_day("2019-10-27", "header_field_manipulation")
+    list_cans_on_s3_for_a_day("2019-10-28", "header_field_manipulation")
+    list_cans_on_s3_for_a_day("2019-10-29", "header_field_manipulation")
+    list_cans_on_s3_for_a_day("2019-10-30", "header_field_manipulation")
+    list_cans_on_s3_for_a_day("2019-10-31", "header_field_manipulation")
+    assert 0
+
 def log_obj(o):
     log.info(ujson.dumps(o, sort_keys=True, ensure_ascii=False, indent=2))
 

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -125,9 +125,12 @@ def setup_module(module):
 def test_telegram(cans):
     can = cans["telegram"]
     for msm in load_can(can):
-        summary = fp.score_measurement(msm, [])
-        if msm["report_id"] == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0":
-            assert summary["scores"] == {
+        scores = fp.score_measurement(msm, [])
+        if (
+            msm["report_id"]
+            == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0"
+        ):
+            assert scores == {
                 "blocking_general": 1.5,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -140,8 +143,11 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
             }, msm
 
-        elif msm["report_id"] == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r":
-            assert summary["scores"] == {
+        elif (
+            msm["report_id"]
+            == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r"
+        ):
+            assert scores == {
                 "blocking_general": 1.0,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -154,8 +160,11 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
                 "msg": "Telegam failure: connection_reset",
             }
-        elif msm["report_id"] == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM":
-            assert summary["scores"] == {
+        elif (
+            msm["report_id"]
+            == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM"
+        ):
+            assert scores == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -168,8 +177,11 @@ def test_telegram(cans):
                 "http_failure_cnt": 10,
                 "msg": "Telegam failure: generic_timeout_error",
             }
-        elif msm["report_id"] == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz":
-            assert summary["scores"] == {
+        elif (
+            msm["report_id"]
+            == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz"
+        ):
+            assert scores == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -188,9 +200,12 @@ def test_whatsapp(cans):
     can = cans["whatsapp"]
     debug = False
     for msm in load_can(can):
-        summary = fp.score_measurement(msm, [])
-        if msm["report_id"] == "20190830T002828Z_AS209_fDHPMTveZ66kGmktmW8JiGDgqAJRivgmBkZjAVRmFbH92OIlTX":
-            assert summary["scores"] == {
+        scores = fp.score_measurement(msm, [])
+        if (
+            msm["report_id"]
+            == "20190830T002828Z_AS209_fDHPMTveZ66kGmktmW8JiGDgqAJRivgmBkZjAVRmFbH92OIlTX"
+        ):
+            assert scores == {
                 "blocking_general": 0.8,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -198,11 +213,14 @@ def test_whatsapp(cans):
                 "blocking_local": 0.0,
             }, msm
 
-        if msm["report_id"] == "20190829T002541Z_AS29119_kyaEYabRxQW6q41n4kPH9aX5cvFEXNheCj1fguSf4js3JydUbr":
+        if (
+            msm["report_id"]
+            == "20190829T002541Z_AS29119_kyaEYabRxQW6q41n4kPH9aX5cvFEXNheCj1fguSf4js3JydUbr"
+        ):
             # The probe is reporting a false positive: due to the empty client headers
             # it hits https://www.whatsapp.com/unsupportedbrowser
             print_msm(msm)
-            assert summary["scores"] == {
+            assert scores == {
                 "blocking_general": 0.0,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -211,9 +229,9 @@ def test_whatsapp(cans):
             }, msm
 
         # To inspect the test dataset for false positives run this:
-        if debug and summary["scores"]["blocking_general"] > 0:
+        if debug and scores["blocking_general"] > 0:
             print_msm(msm)
-            print(summary["scores"])
+            print(scores)
             raise Exception("debug")
 
 
@@ -221,13 +239,19 @@ def test_facebook_messenger(cans):
     can = cans["facebook_messenger"]
     debug = False
     for msm in load_can(can):
-        summary = fp.score_measurement(msm, [])
-        if msm["report_id"] != "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC":
+        scores = fp.score_measurement(msm, [])
+        if (
+            msm["report_id"]
+            != "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC"
+        ):
             continue
 
-        if msm["report_id"] == "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC":
+        if (
+            msm["report_id"]
+            == "20190829T105137Z_AS6871_TJfyRlEkm6BaCfszHr06nC0c9UsWjWt8mCxRBw1jr0TeqcHTiC"
+        ):
             # not blocked
-            assert summary["scores"] == {
+            assert scores == {
                 "blocking_general": 0.0,
                 "blocking_global": 0.0,
                 "blocking_country": 0.0,
@@ -238,9 +262,9 @@ def test_facebook_messenger(cans):
         # TODO: add more
 
         # To inspect the test dataset for false positives run this:
-        elif debug and summary["scores"]["blocking_general"] > 0:
+        elif debug and scores["blocking_general"] > 0:
             print_msm(msm)
-            print(summary["scores"])
+            print(scores)
 
     if debug:
         raise Exception("debug")
@@ -250,11 +274,14 @@ def test_facebook_messenger(cans):
 def test_facebook_messenger_bug(cans):
     can = cans["facebook_messenger"]
     for msm in load_can(can):
-        summary = fp.score_measurement(msm, [])
-        if msm["report_id"] != "20190829T000015Z_AS137_6FCvPkYvOAPUqKgO8QdllyWXTPXUbUAVV3cA43E6drE0KAe4iO":
+        scores = fp.score_measurement(msm, [])
+        if (
+            msm["report_id"]
+            != "20190829T000015Z_AS137_6FCvPkYvOAPUqKgO8QdllyWXTPXUbUAVV3cA43E6drE0KAe4iO"
+        ):
             continue
 
-        assert summary["scores"] == {
+        assert scores == {
             "blocking_general": 0.0,
             "blocking_global": 0.0,
             "blocking_country": 0.0,
@@ -268,26 +295,31 @@ def test_facebook_messenger_newer(cans):
     blocked_cnt = 0
     debug = False
     for tot, msm in enumerate(load_can(can)):
-        summary = fp.score_measurement(msm, [])
+        scores = fp.score_measurement(msm, [])
         rid = msm["report_id"]
 
-        if rid == "20191029T101630Z_AS56040_bBOkNtg65fMfH0iOHiG8lMk4UmERxjfJL20ki33lKlyKjS0FkP":
+        if (
+            rid
+            == "20191029T101630Z_AS56040_bBOkNtg65fMfH0iOHiG8lMk4UmERxjfJL20ki33lKlyKjS0FkP"
+        ):
             # TCP really blocked
-            assert summary["scores"]["blocking_general"] >= 1.0
+            assert scores["blocking_general"] >= 1.0
             continue
 
-        elif rid == "20191029T020948Z_AS50010_ZUPoP3hOdwazqZnzPurdWgfLvoMcDL1qyOHHFtEtISjNWMgkrX":
+        elif (
+            rid
+            == "20191029T020948Z_AS50010_ZUPoP3hOdwazqZnzPurdWgfLvoMcDL1qyOHHFtEtISjNWMgkrX"
+        ):
             # DNS returns mostly 0.0.0.0 - but one connection succeeds
-            assert summary["scores"]["blocking_general"] >= 1.0
+            assert scores["blocking_general"] >= 1.0
             continue
 
-        elif summary["scores"]["blocking_general"] > 0:
+        elif scores["blocking_general"] > 0:
             blocked_cnt += 1
             if debug:
-                print(msm["probe_cc"], msm["software_name"],
-                    msm["software_version"])
+                print(msm["probe_cc"], msm["software_name"], msm["software_version"])
                 print_msm(msm)
-                print(summary["scores"])
+                print(scores)
 
     ratio = blocked_cnt / (tot + 1) * 100
     assert ratio > 7.656

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -1,6 +1,7 @@
 """
 Simulate feeding from the collectors or cans on S3 using a local can
 """
+# Format with black -t py37 -l 120
 
 from pathlib import Path
 import logging
@@ -114,8 +115,7 @@ def test_telegram(cans):
         if msm is None:
             msm = ujson.loads(msm_jstr)
         summary = fp.score_measurement(msm, [])
-        # fmt: off
-        if (msm["report_id"] == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0"):
+        if msm["report_id"] == "20190830T002837Z_AS209_3nMvNkLIqSZMLqRiaiQylAuHxu6qpK7rVJcAA9Dv2UpcNMhPH0":
             assert summary["scores"] == {
                 "blocking_general": 1.5,
                 "blocking_global": 0.0,
@@ -129,7 +129,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
             }, msm
 
-        elif (msm["report_id"] == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r"):
+        elif msm["report_id"] == "20190829T205910Z_AS45184_0TVMQZLWjkfOdqA5b5nNF1XHrafTD4H01GnVTwvfzfiLyLc45r":
             assert summary["scores"] == {
                 "blocking_general": 1.0,
                 "blocking_global": 0.0,
@@ -143,7 +143,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 0,
                 "msg": "Telegam failure: connection_reset",
             }
-        elif (msm["report_id"] == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM"):
+        elif msm["report_id"] == "20190829T210302Z_AS197207_28cN0a47WSIxF3SZlXvceoLCSk3rSkyeg0n07pKGAi7XYyEQXM":
             assert summary["scores"] == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
@@ -157,7 +157,7 @@ def test_telegram(cans):
                 "http_failure_cnt": 10,
                 "msg": "Telegam failure: generic_timeout_error",
             }
-        elif (msm["report_id"] == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz"):
+        elif msm["report_id"] == "20190829T220118Z_AS16345_28eP4Hw7PQsLmb4eEPWitNvIZH8utHddaTbWZ9qFcaZudmHPfz":
             assert summary["scores"] == {
                 "blocking_general": 3.0,
                 "blocking_global": 0.0,
@@ -171,7 +171,6 @@ def test_telegram(cans):
                 "http_failure_cnt": 10,
                 "msg": "Telegam failure: connect_error",
             }
-        # fmt: on
 
 
 def test_whatsapp(cans):
@@ -204,11 +203,8 @@ def test_whatsapp(cans):
             }, msm
 
         # To inspect the test dataset for false positives run this:
-        if debug:
-            if summary["scores"]["blocking_general"] > 0:
-                print("-----")
-                print_msm(msm)
-                print(summary["scores"])
-
-    if debug:
-        assert 0, "Debug"
+        if debug and summary["scores"]["blocking_general"] > 0:
+            print("-----")
+            print_msm(msm)
+            print(summary["scores"])
+            raise Exception("debug")

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -670,18 +670,15 @@ def test_score_psiphon(cans):
     for can_fn, msm in s3msmts("psiphon", start_date=date(2019, 9, 12)):
         # The earliest can is canned/2019-09-12/psiphon.0.tar.lz4
         rid = msm["report_id"]
-        if "resolver_ip" not in msm:
-            # Some msmts are missing this
-            continue
-
-        assert sorted(msm) == [
+        mkeys = set(msm.keys())
+        mkeys.discard("resolver_ip") # Some msmts are missing this
+        assert sorted(mkeys) == [
             "data_format_version",
             "measurement_start_time",
             "probe_asn",
             "probe_cc",
             "probe_ip",
             "report_id",
-            "resolver_ip",
             "software_name",
             "software_version",
             "test_keys",
@@ -691,7 +688,7 @@ def test_score_psiphon(cans):
             "test_version",
         ], "https://explorer.ooni.org/measurement/{}".format(rid)
         assert sorted(msm["test_keys"]) == ["bootstrap_time", "failure"]
-        # TODO: all msmts have empty failure. No scoring is done.
+        # TODO: all msmts have empty test_keys->failure. No scoring is done.
         assert msm["test_keys"]["failure"] == ""
         assert 0 < msm["test_keys"]["bootstrap_time"] < 100
         scores = fp.score_measurement(msm, [])

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -60,6 +60,10 @@ def cans():
         dash_2019_10_28="2019-10-28/dash.0.tar.lz4",
         dash_2019_10_29="2019-10-29/dash.0.tar.lz4",
         hirl_2019_10_26="2019-10-26/http_invalid_request_line.0.tar.lz4",
+        meek_2019_10_26="2019-10-26/meek_fronted_requests_test.0.tar.lz4",
+        meek_2019_10_27="2019-10-27/meek_fronted_requests_test.0.tar.lz4",
+        meek_2019_10_28="2019-10-28/meek_fronted_requests_test.0.tar.lz4",
+        meek_2019_10_29="2019-10-29/meek_fronted_requests_test.0.tar.lz4",
     )
     for k, v in _cans.items():
         _cans[k] = Path("testdata") / v
@@ -585,3 +589,40 @@ def test_score_dash(cans):
                 expected.pop(rid)
 
     assert len(expected) == 0, expected.keys()
+
+
+def test_score_meek_fronted_requests_test(cans):
+    debug = 0
+    for d in range(26, 30):
+        can = cans["meek_2019_10_{}".format(d)]
+        for msm in load_can(can):
+            rid = msm["report_id"]
+            inp = msm["input"]
+            scores = fp.score_measurement(msm, [])
+            if rid == "20191026T110224Z_AS3352_2Iqv4PvPItJ2Z3D46wVRHzesBpdDJZ8xDKH7VKqNTebaiGopDY":
+                # response: None
+                assert scores["blocking_general"] == 1.0
+
+            elif rid == "20191026T000021Z_AS137_0KaXWBZgn8W6iMfKKhjHJPoPPovChlwxr8dDOh4LxTzHDOKLOq":
+                # One response: 404
+                assert scores["blocking_general"] == 1.0
+
+            elif rid == "20191026T000034Z_AS42668_vpZnPVKEym0dRgYSxyeZulPvnLtxrh6HXzyMx5tE2f4x26CBwX":
+                # 403 hitting cloudfront
+                # Content-Type: text/html
+                # Date: Sat, 26 Oct 2019 01:01:21 GMT
+                # Server: CloudFront
+                # Via: 1.1 60858c13889b9be849ae025edc06577d.cloudfront.net (CloudFront)
+                # X-Amz-Cf-Pop: ARN53
+                # X-Cache: Error from cloudfront
+                assert scores["blocking_general"] == 1.0
+
+            elif rid == "20191026T001625Z_AS19108_G9uGTtyJCiOzeCm4jHsP6r8WRZ8cWx07wvcjwAVmrTshJ8WYwA":
+                # requests: is empty
+                assert scores["accuracy"] == 0
+
+            elif debug:
+                print("https://explorer.ooni.org/measurement/{}".format(rid))
+                print_msm(msm)
+                print(scores)
+                assert 0

--- a/af/oometa/018-fastpath.install.sql
+++ b/af/oometa/018-fastpath.install.sql
@@ -35,6 +35,7 @@ COMMENT ON COLUMN fastpath.filename IS 'File served by the fastpath host contain
 
 COMMENT ON COLUMN fastpath.scores IS 'Scoring metadata';
 
+-- TODO add these to ansible role
 -- Skip grants during tests on Travis CI
 DO $$
 BEGIN


### PR DESCRIPTION
Version 0.3
Detect and score blocking of:
- Facebook Messenger
- Telegram
- Whatsapp
- Header field manipulation test
- Vanilla Tor connectivity test
- TCP connect test
- DASH Dynamic Adaptive Streaming over HTTP
- Meek

Basic handling (without scoring) of:
- Psiphon
- NDT

Minor improvements
