### PR TITLE
0.12 Install domain input updater

### DIFF
--- a/af/fastpath/debian/changelog
+++ b/af/fastpath/debian/changelog
@@ -1,8 +1,14 @@
-fastpath (0.11) UNRELEASED; urgency=medium
+fastpath (0.12) unstable; urgency=medium
+
+  * Install domain_input_updater executable
+
+ -- Federico Ceratto <federico@debian.org>  Mon, 20 Jan 2020 12:23:04 +0000
+
+fastpath (0.11) unstable; urgency=medium
 
   * Retry SSH connections on failure
 
- -- Federico Ceratto <federico@debian.org>  Fri, 17 Jan 2020 19:25:13 +0000
+ -- Federico Ceratto <federico@debian.org>  Mon, 20 Jan 2020 12:22:35 +0000
 
 fastpath (0.10) unstable; urgency=medium
 

--- a/af/fastpath/setup.py
+++ b/af/fastpath/setup.py
@@ -14,6 +14,7 @@ setup(
     packages=["fastpath", "fastpath.tests"],
     entry_points={"console_scripts": [
         "fastpath=fastpath.core:main",
+        "domain_input_updater=fastpath.domain_input:main",
     ]},
     install_requires=REQUIRED,
     include_package_data=True,


### PR DESCRIPTION
Related to https://github.com/ooni/backend/issues/287
Install domain_input_updater
Add dry run mode and basic summary:
`230075 629465 INFO fastpath.domain_input Valid inputs: 1527774 invalid: 47654 invalid percentage: 3.024829`
