### PR TITLE
Analysis 0.3 restart on watchdog failure

### DIFF
--- a/af/analysis/debian/analysis.service
+++ b/af/analysis/debian/analysis.service
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 ExecStart=/usr/bin/analysis
-Restart=on-abort
+Restart=on-failure
 Type=simple
 RestartSec=2s
 WorkingDirectory=/var/lib/analysis

--- a/af/analysis/debian/changelog
+++ b/af/analysis/debian/changelog
@@ -1,3 +1,9 @@
+analysis (0.3) unstable; urgency=medium
+
+  * Fix watchdog
+
+ -- Federico Ceratto <federico@debian.org>  Wed, 12 Feb 2020 18:10:53 +0000
+
 analysis (0.2) unstable; urgency=medium
 
   * extended DB metrics gathering


### PR DESCRIPTION
Set Restart=on-failure is systemd unit file to restart the service
on watchdog failure.
Improve logging, remove double negations like "no_systemd == False"