### PR TITLE
FP 0.20 Score web_connectivity using "blocking"

### DIFF
--- a/af/fastpath/debian/changelog
+++ b/af/fastpath/debian/changelog
@@ -1,3 +1,9 @@
+fastpath (0.20) unstable; urgency=medium
+
+  * Handle blocking types in web_connectivity #352
+
+ -- Federico Ceratto <federico@debian.org>  Mon, 02 Mar 2020 17:39:49 +0000
+
 fastpath (0.19) unstable; urgency=medium
 
   * Allow importing domain_input_updater

--- a/af/fastpath/fastpath/core.py
+++ b/af/fastpath/fastpath/core.py
@@ -839,6 +839,11 @@ def score_web_connectivity(msm, matches) -> dict:
         delta = abs((tk["body_proportion"] or 1.0) - 1.0)
         scores["blocking_general"] += delta
 
+    if tk.get("http_experiment_failure", "").startswith("unknown_failure"):
+        # bug#351
+        log.debug("bug#351")
+        scores["accuracy"] = 0.0
+
     # TODO: add heuristic to split blocking_general into local/ISP/country/global
     scores["blocking_general"] += (
         scores["blocking_country"]

--- a/af/fastpath/fastpath/db.py
+++ b/af/fastpath/fastpath/db.py
@@ -134,9 +134,8 @@ def upsert_summary(
         cur.execute(tpl, args)
         if cur.rowcount == 0 and not update:
             metrics.incr("report_id_input_db_collision")
-            log.info(
-                "report_id / input collision %r %r", msm["report_id"], msm["input"]
-            )
+            inp = msm.get("input", "<no input>")
+            log.info(f"report_id / input collision {msm['report_id']} {inp}")
             return
 
         notification = {k: msm.get(k, None) for k in cols}

--- a/af/fastpath/fastpath/db.py
+++ b/af/fastpath/fastpath/db.py
@@ -131,7 +131,12 @@ def upsert_summary(
     )
 
     with _autocommit_conn.cursor() as cur:
-        cur.execute(tpl, args)
+        try:
+            cur.execute(tpl, args)
+        except psycopg2.ProgrammingError:
+            log.error("upsert syntax error in %r", tpl, exc_info=True)
+            return
+
         if cur.rowcount == 0 and not update:
             metrics.incr("report_id_input_db_collision")
             inp = msm.get("input", "<no input>")

--- a/af/fastpath/fastpath/db.py
+++ b/af/fastpath/fastpath/db.py
@@ -91,7 +91,7 @@ def upsert_summary(
         scores = excluded.scores,
         anomaly = excluded.anomaly,
         confirmed = excluded.confirmed,
-        msm_failure = excluded.msm_failure,
+        msm_failure = excluded.msm_failure
     """
     )
     sql_noupdate = " NOTHING"

--- a/af/fastpath/fastpath/s3feeder.py
+++ b/af/fastpath/fastpath/s3feeder.py
@@ -140,8 +140,11 @@ def fetch_cans(s3, conf, files):
         _cb.count += bytes_count
         _cb.total_count += bytes_count
         metrics.gauge("s3_download_percentage", _cb.total_count / _cb.total_size * 100)
-        speed = _cb.count / 131_072 / (time.time() - _cb.start_time)
-        metrics.gauge("s3_download_speed_avg_Mbps", speed)
+        try:
+            speed = _cb.count / 131_072 / (time.time() - _cb.start_time)
+            metrics.gauge("s3_download_speed_avg_Mbps", speed)
+        except ZeroDivisionError:
+            pass
 
     _cb.total_size = sum(t[2] for t in to_dload)
     _cb.total_count = 0

--- a/af/fastpath/fastpath/sshfeeder.py
+++ b/af/fastpath/fastpath/sshfeeder.py
@@ -203,9 +203,11 @@ def log_ingestion_delay(msm_jstr, msm):
         now = datetime.datetime.utcnow()
         s = (now - st).total_seconds()
         if s < 0:
-            s = 0
-        metrics.gauge("ingestion_delay", s)
+            metrics.gauge("negative_ingestion_delay", -s)
+        else:
+            metrics.gauge("ingestion_delay", s)
     except:
+        log.warning("Failed to parse %r", msm.get("measurement_start_time", ""))
         pass
 
 

--- a/af/fastpath/fastpath/tests/data/bug_351.json
+++ b/af/fastpath/fastpath/tests/data/bug_351.json
@@ -1,0 +1,124 @@
+{
+  "annotations": {
+    "platform": "linux"
+  },
+  "backend_version": null,
+  "bucket_date": "2020-02-29",
+  "data_format_version": "0.2.0",
+  "id": "b6b5e56a-3513-4cd1-92a3-516ba7d3eaf6",
+  "input": "https://fa.wikipedia.org/",
+  "input_hashes": [],
+  "measurement_start_time": "2020-02-29 01:51:41",
+  "options": [
+    "--file",
+    "$citizenlab_${probe_cc}_urls"
+  ],
+  "probe_asn": "AS5390",
+  "probe_cc": "NL",
+  "probe_city": null,
+  "probe_ip": "127.0.0.1",
+  "report_filename": "2020-02-29/20200229T014315Z-NL-AS5390-web_connectivity-20200229T014316Z_AS5390_bByhuFiqtRyhhfSSkkoFybwU7dQorWUP45zEjJdwjd0LIYmFLJ-0.2.0-probe.json",
+  "report_id": "20200229T014316Z_AS5390_bByhuFiqtRyhhfSSkkoFybwU7dQorWUP45zEjJdwjd0LIYmFLJ",
+  "software_name": "ooniprobe",
+  "software_version": "2.2.0",
+  "test_helpers": {
+    "backend": {
+      "address": "httpo://y3zq5fwelrzkkv3s.onion",
+      "type": "onion"
+    }
+  },
+  "test_keys": {
+    "accessible": false,
+    "agent": "redirect",
+    "blocking": "http-failure",
+    "body_length_match": null,
+    "client_resolver": "0.0.0.0",
+    "control": {
+      "dns": {
+        "addrs": [
+          "dyna.wikimedia.org",
+          "91.198.174.192"
+        ],
+        "failure": null
+      },
+      "http_request": {
+        "body_length": 127734,
+        "failure": null,
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Age": "38646",
+          "Backend-Timing": "D=140953 t=1582902458777131",
+          "Cache-Control": "private, s-maxage=0, max-age=0, must-revalidate",
+          "Content-Type": "text/html; charset=UTF-8",
+          "Content-language": "fa",
+          "Date": "Fri, 28 Feb 2020 15:07:38 GMT",
+          "Last-Modified": "Fri, 28 Feb 2020 15:04:36 GMT",
+          "P3P": "CP=\"See https://fa.wikipedia.org/wiki/Special:CentralAutoLogin/P3P for more info.\"",
+          "Server": "mw1251.eqiad.wmnet",
+          "Server-Timing": "cache;desc=\"hit-front\"",
+          "Set-Cookie": "WMF-Last-Access=29-Feb-2020;Path=/;HttpOnly;secure;Expires=Wed, 01 Apr 2020 00:00:00 GMT",
+          "Strict-Transport-Security": "max-age=106384710; includeSubDomains; preload",
+          "Vary": "Accept-Encoding,Cookie,Authorization",
+          "X-ATS-Timestamp": "1582902459",
+          "X-Cache": "cp3064 miss, cp3064 hit/330",
+          "X-Cache-Status": "hit-front",
+          "X-Client-IP": "37.218.247.47",
+          "X-Content-Type-Options": "nosniff",
+          "X-Powered-By": "PHP/7.2.26-1+0~20191218.33+debian9~1.gbpb5a340+wmf1",
+          "X-Varnish": "189328748 548738152"
+        },
+        "status_code": 200,
+        "title": "  "
+      },
+      "tcp_connect": {
+        "91.198.174.192:443": {
+          "failure": null,
+          "status": true
+        }
+      }
+    },
+    "control_failure": null,
+    "dns_consistency": "consistent",
+    "dns_experiment_failure": null,
+    "headers_match": null,
+    "http_experiment_failure": "unknown_failure 'ascii' codec can't decode byte 0xd9 in position 101: ordinal not in range(128)",
+    "queries": [
+      {
+        "answers": [
+          {
+            "answer_type": "CNAME",
+            "hostname": "dyna.wikimedia.org"
+          },
+          {
+            "answer_type": "A",
+            "ipv4": "91.198.174.192"
+          }
+        ],
+        "failure": null,
+        "hostname": "fa.wikipedia.org",
+        "query_type": "A",
+        "resolver_hostname": null,
+        "resolver_port": null
+      }
+    ],
+    "requests": [],
+    "retries": 1,
+    "socksproxy": null,
+    "status_code_match": null,
+    "tcp_connect": [
+      {
+        "ip": "91.198.174.192",
+        "port": 443,
+        "status": {
+          "blocked": false,
+          "failure": null,
+          "success": true
+        }
+      }
+    ]
+  },
+  "test_name": "web_connectivity",
+  "test_runtime": 2.1714069843,
+  "test_start_time": "2020-02-29 01:43:15",
+  "test_version": "0.3.0"
+}

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -560,7 +560,7 @@ def test_score_vanilla_tor(cans):
     assert 0.003 < avg < 0.004
 
 
-def test_score_web_connectivity(cans):
+def test_score_web_connectivity_simple(cans):
     debug = 0
     blocked = (
         "20191029T180431Z_AS50289_5IKNXzKJUvzKQqnlzU5r91F9KiCl1LfRlEBllZVbDHcDQg5TEt",

--- a/af/fastpath/fastpath/tests/test_functional.py
+++ b/af/fastpath/fastpath/tests/test_functional.py
@@ -292,12 +292,14 @@ def test_whatsapp(cans):
         if rid == "20190830T002828Z_AS209_fDHPMTveZ66kGmktmW8JiGDgqAJRivgmBkZjAVRmFbH92OIlTX":
             # empty test_keys -> requests
             log.error(scores)
-            assert scores == {'accuracy': 0.0,
-                  'blocking_country': 0.0,
-                  'blocking_general': 0.0,
-                  'blocking_global': 0.0,
-                  'blocking_isp': 0.0,
-                  'blocking_local': 0.0}
+            assert scores == {
+                "accuracy": 0.0,
+                "blocking_country": 0.0,
+                "blocking_general": 0.0,
+                "blocking_global": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
 
         elif rid == "20190829T002541Z_AS29119_kyaEYabRxQW6q41n4kPH9aX5cvFEXNheCj1fguSf4js3JydUbr":
             # The probe is reporting a false positive: due to the empty client headers
@@ -308,10 +310,10 @@ def test_whatsapp(cans):
                 "blocking_country": 0.0,
                 "blocking_isp": 0.0,
                 "blocking_local": 0.0,
-                'analysis': {
-                    'registration_server_accessible': True,
-                    'whatsapp_endpoints_accessible': True,
-                    'whatsapp_web_accessible': True
+                "analysis": {
+                    "registration_server_accessible": True,
+                    "whatsapp_endpoints_accessible": True,
+                    "whatsapp_web_accessible": True,
                 },
             }, msm
 
@@ -333,12 +335,13 @@ def test_whatsapp_probe_bug(cans):
         scores = fp.score_measurement(msm, [])
         assert scores["blocking_general"] in (0.0, 1.0)
         if "analysis" in scores:
-            assert scores["analysis"]["whatsapp_web_accessible"] in (True, False), ujson.dumps(msm, indent=1, sort_keys=True)
+            assert scores["analysis"]["whatsapp_web_accessible"] in (True, False), ujson.dumps(
+                msm, indent=1, sort_keys=True
+            )
             if debug and scores["blocking_general"] > 0:
                 print_msm(msm)
                 print(scores)
                 raise Exception("debug")
-
 
 
 def test_facebook_messenger(cans):
@@ -469,7 +472,10 @@ def test_score_measurement_hhfm_large(cans):
             elif debug and scores["blocking_general"] == 1.1:
                 url = "https://explorer.ooni.org/measurement/{}".format(rid)
                 print(
-                    msm["test_start_time"], msm["probe_cc"], url, msm["test_keys"]["requests"][0].get("failure", None)
+                    msm["test_start_time"],
+                    msm["probe_cc"],
+                    url,
+                    msm["test_keys"]["requests"][0].get("failure", None),
                 )
                 print_msm(msm)
                 print(scores)
@@ -561,40 +567,91 @@ def test_score_vanilla_tor(cans):
 
 
 def test_score_web_connectivity_simple(cans):
-    debug = 0
-    blocked = (
-        "20191029T180431Z_AS50289_5IKNXzKJUvzKQqnlzU5r91F9KiCl1LfRlEBllZVbDHcDQg5TEt",
-        "20191029T180509Z_AS50289_CqU5a3scgi1JJ8cWEYEMSqLUzseS0uIbnWcnGSKKlW1BMbnLc5",
-    )
-    nonblocked = (
-        "20191029T180447Z_AS50289_yWeX5dJzPeh9Pk3TddqG2eO3BvLGT2SOWmOK0lhR7aRV0XX1RC",
-        "20191029T180452Z_AS50289_IIuYcQRCGA9S2cj5zFABEOvMbyXSKBExWywVgZkpe5l1uAqyT5",
-        "20191029T180525Z_AS50289_UfjRU99n2edoDn9PeWnqyGxHVorOAxBFwZj3WPQ24sl2ii4gC2",
-    )
+    # (rid, inp) -> scores: exact match on scores
+    expected = {
+        (
+            "20191104T000516Z_AS52871_uFya6RnctQPrBVEdxE9uUpOxia9frBkNXkP9ZNmhQPEFoKqJ0l",
+            "https://100ko.wordpress.com/",
+        ): {
+            # unknown_failure
+            "scores": {
+                "accuracy": 0.0,
+                "analysis": {"blocking_type": "http-failure"},
+                "blocking_country": 0.0,
+                "blocking_general": 1.0,
+                "blocking_global": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
+        },
+        (
+            "20191104T032906Z_AS8402_fY9b9V3jLtosTMNJbub1xNvuKBpZwPXTp7df9NLw6Sp4QOnXIz",
+            "http://www.ohchr.org/",
+        ): {
+            "scores": {
+                "blocking_country": 0.0,
+                "blocking_general": 0.0,
+                "blocking_global": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
+        },
+        (
+            "20191101T015523Z_AS0_muvGSfWmgRobU77ZL980XGRTyJ80HC0ubQ5YaPaYiotxiXL6po",
+            "http://www.newnownext.com/franchise/the-backlot/",
+        ): {
+            "scores": {
+                "analysis": {"blocking_type": "http-diff"},
+                "blocking_country": 0.0,
+                "blocking_general": 1.0,
+                "blocking_global": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
+        },
+        (
+            "20191101T071829Z_AS0_sq5lk0Y4jhCECrgk2pAgMWlgOczBLDkIb2OE9QnHf1OEOmwOBz",
+            "http://www.lingeriebowl.com",
+        ): {
+            "scores": {
+                "analysis": {"blocking_type": "dns"},
+                "blocking_country": 0.0,
+                "blocking_general": 1.0,
+                "blocking_global": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
+        },
+        ("20191101T071829Z_AS0_sq5lk0Y4jhCECrgk2pAgMWlgOczBLDkIb2OE9QnHf1OEOmwOBz", "http://www.pravda.ru"): {
+            # In this msmt title_match is false due to the probe following a redirect.
+            # The probe uses:
+            # (body_length_match or headers_match or title_match) and (status_code_match != false)
+            "scores": {
+                "blocking_general": 0.0,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
+        },
+    }
 
-    # In this msmt the probe follows a redirect and lands on a page with a
-    # title in russian, while the probe gets title " - "
-    # https://explorer.ooni.org/measurement/20191101T071829Z_AS0_sq5lk0Y4jhCECrgk2pAgMWlgOczBLDkIb2OE9QnHf1OEOmwOBz?input=http://www.pravda.ru
-
-    # The probe uses:
-    # (body_length_match or headers_match or title_match) and (status_code_match != false)
 
     for can_fn, msm in s3msmts("web_connectivity", start_date=date(2019, 11, 1)):
         rid = msm["report_id"]
         inp = msm["input"]
         scores = fp.score_measurement(msm, [])
-        bl = sum(scores[k] for k in scores if k.startswith("blocking_"))
-        if rid in blocked:
-            assert bl > 0
 
-        elif rid in nonblocked:
-            assert bl < 0.3
+        if (rid, inp) not in expected:
+            # log.warning(f"https://explorer.ooni.org/measurement/{rid}?input={inp}")
+            # log.warning((rid, inp, scores))
+            continue
 
-        elif debug and bl > 0:
-            print("https://explorer.ooni.org/measurement/{}?input={}".format(rid, inp))
-            print_msm(msm)
-            print(scores)
-            assert 0
+        exp = expected.pop((rid, inp))
+        if "scores" in exp:
+            assert scores == exp["scores"]
+
+    assert len(expected) == 0, "Not all expected measurements were tested"
 
 
 def test_score_web_connectivity_with_workers(cans):
@@ -722,19 +779,51 @@ def test_score_tcp_connect(cans):
 def test_score_dash(cans):
     # rid -> blocking_general, accuracy
     expected = {
-        "20191026T015105Z_AS4837_7vwBtbVmZZqwZhdTHnqHan0Nwa7bi7TeJ789htG3RB91C3eyU1": (0.1, 0.0, "blocking_general"),
-        "20191026T022317Z_AS17380_ZJGnXdvHl4j1M4xTeskrGhC8SW1KT4buJEjxCsTagCGO2NZeAD": (0.1, 0.0, "json_parse_error"),
-        "20191026T032159Z_AS20057_xLjBSrTyZjOn6C7pa5BPyUxyBhzWHbSooKQjUY9zcWADnkakIR": (0.1, 0.0, "eof_error"),
+        "20191026T015105Z_AS4837_7vwBtbVmZZqwZhdTHnqHan0Nwa7bi7TeJ789htG3RB91C3eyU1": (
+            0.1,
+            0.0,
+            "blocking_general",
+        ),
+        "20191026T022317Z_AS17380_ZJGnXdvHl4j1M4xTeskrGhC8SW1KT4buJEjxCsTagCGO2NZeAD": (
+            0.1,
+            0.0,
+            "json_parse_error",
+        ),
+        "20191026T032159Z_AS20057_xLjBSrTyZjOn6C7pa5BPyUxyBhzWHbSooKQjUY9zcWADnkakIR": (
+            0.1,
+            0.0,
+            "eof_error",
+        ),
         "20191026T051350Z_AS44244_9yjPG1UbgIjtAFg9LiTUxVhq7hGuG3tG4yMnvt6gRJTaFdQme6": (
             0.1,
             0.0,
             "json_processing_error",
         ),
-        "20191026T071332Z_AS7713_caK9GNyp9ZhN7zL9cg2dg0zGhs44CwHmxZtOyK7B6rBKRaGGMF": (0.1, 0.0, "http_request_failed"),
-        "20191026T093003Z_AS4837_yHZ0f8Oxyhus9vBKAUa0tA2XMSObIO0frShG6YBieBzY9RiSBg": (0.1, 0.0, "connect_error"),
-        "20191026T165434Z_AS0_qPbZHZF8VXUWgzlvqT9Jd7ARuHSl2Dq4tPcEq580rgYZGmV5Um": (0.1, 0.0, "generic_timeout_error"),
-        "20191028T160112Z_AS1640_f4zyjjp5vFcwZkAKPrTokayPRdcXPfdEMRbdo1LmIaLZRile6P": (0.1, 0.0, "broken_pipe"),
-        "20191029T094043Z_AS49048_qGQxBh6lv26TOfuWfhGcUtz2LZWwboXlfbh058CSF1fOmEUv6Z": (0.1, 0.0, "connection_refused"),
+        "20191026T071332Z_AS7713_caK9GNyp9ZhN7zL9cg2dg0zGhs44CwHmxZtOyK7B6rBKRaGGMF": (
+            0.1,
+            0.0,
+            "http_request_failed",
+        ),
+        "20191026T093003Z_AS4837_yHZ0f8Oxyhus9vBKAUa0tA2XMSObIO0frShG6YBieBzY9RiSBg": (
+            0.1,
+            0.0,
+            "connect_error",
+        ),
+        "20191026T165434Z_AS0_qPbZHZF8VXUWgzlvqT9Jd7ARuHSl2Dq4tPcEq580rgYZGmV5Um": (
+            0.1,
+            0.0,
+            "generic_timeout_error",
+        ),
+        "20191028T160112Z_AS1640_f4zyjjp5vFcwZkAKPrTokayPRdcXPfdEMRbdo1LmIaLZRile6P": (
+            0.1,
+            0.0,
+            "broken_pipe",
+        ),
+        "20191029T094043Z_AS49048_qGQxBh6lv26TOfuWfhGcUtz2LZWwboXlfbh058CSF1fOmEUv6Z": (
+            0.1,
+            0.0,
+            "connection_refused",
+        ),
     }
     for d in range(26, 30):
         can = cans["dash_2019_10_{}".format(d)]
@@ -802,9 +891,13 @@ def test_score_psiphon(cans):
         assert msm["test_keys"]["failure"] is None, msm
         scores = fp.score_measurement(msm, [])
         if rid == "20200109T111813Z_AS30722_RZeO9Ix6ET2LJzqGcinrDp1iqrhaGGDCHSwlOoybq2N9kZITQt":
-            assert scores == {'blocking_general': 0.0, 'blocking_global': 0.0,
-                              'blocking_country': 0.0, 'blocking_isp': 0.0,
-                              'blocking_local': 0.0}
+            assert scores == {
+                "blocking_general": 0.0,
+                "blocking_global": 0.0,
+                "blocking_country": 0.0,
+                "blocking_isp": 0.0,
+                "blocking_local": 0.0,
+            }
 
 
 # See test_score_tor() in test_unit.py

--- a/af/fastpath/fastpath/tests/test_unit.py
+++ b/af/fastpath/fastpath/tests/test_unit.py
@@ -130,7 +130,9 @@ def test_score_tor():
         "blocking_local": 0.0,
     }
 
+
 # # Bug tests
+
 
 def test_bug_backend351():
     # https://api.ooni.io/api/v1/measurement/temp-id-386770148
@@ -141,6 +143,23 @@ def test_bug_backend351():
     assert scores == {
         "accuracy": 0.0,
         "blocking_general": 0.0,
+        "blocking_global": 0.0,
+        "blocking_country": 0.0,
+        "blocking_isp": 0.0,
+        "blocking_local": 0.0,
+    }
+
+
+def test_bug_backend352():
+    # https://github.com/ooni/backend/issues/352
+    # https://explorer.ooni.org/measurement/20200302T130853Z_AS197207_WIN8WWfSysccyZSG06Z5AaMJjSzrvxaq7UOiTnasi52k9D77T3?input=https%3A%2F%2Ffa.wikipedia.org
+    with open("fastpath/tests/data/bug_352.json") as f:
+        msm = ujson.load(f)
+    matches = []
+    scores = fp.score_measurement(msm, matches)
+    assert scores == {
+        "analysis": {"blocking_type": "dns"},
+        "blocking_general": 1.0,
         "blocking_global": 0.0,
         "blocking_country": 0.0,
         "blocking_isp": 0.0,

--- a/af/fastpath/fastpath/tests/test_unit.py
+++ b/af/fastpath/fastpath/tests/test_unit.py
@@ -129,3 +129,20 @@ def test_score_tor():
         "blocking_isp": 0.0,
         "blocking_local": 0.0,
     }
+
+# # Bug tests
+
+def test_bug_backend351():
+    # https://api.ooni.io/api/v1/measurement/temp-id-386770148
+    with open("fastpath/tests/data/bug_351.json") as f:
+        msm = ujson.load(f)
+    matches = []
+    scores = fp.score_measurement(msm, matches)
+    assert scores == {
+        "accuracy": 0.0,
+        "blocking_general": 0.0,
+        "blocking_global": 0.0,
+        "blocking_country": 0.0,
+        "blocking_isp": 0.0,
+        "blocking_local": 0.0,
+    }


### PR DESCRIPTION
Align the behavior of the fastpath with the traditional pipeline
Expose the value of `blocking` in the scores->analysis structure
Handle unknown_failure in any *_failure field

