### PR TITLE
analysis 0.9: Fix replication delay

### DIFF
--- a/af/analysis/debian/changelog
+++ b/af/analysis/debian/changelog
@@ -1,3 +1,9 @@
+analysis (0.9) unstable; urgency=medium
+
+  * Fix replication delay
+
+ -- Federico Ceratto <federico@debian.org>  Fri, 13 Mar 2020 12:54:34 +0000
+
 analysis (0.8) unstable; urgency=medium
 
   * Coalesce NULL inputs used to compare entries in pipeline and fastpath


### PR DESCRIPTION
The replication delay can be misleading in 2 ways due to the measurement based on `now() - pg_last_xact_replay_timestamp()`. The timestamp is based on the last write on the DB.
1) When the active and standby DBs are in sync it shows a delay > 0
2) When the active and standby DBs are out of sync it shows the time difference `now <--> last write on standby` instead of `last write on active <--> last write on standby`

This change fixes 1)